### PR TITLE
feat: add calendar entity for workout events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI workflow (`.github/workflows/ci.yml`) running ruff lint and pytest on every push and pull request
 - Dependabot updates for pip test dependencies
 
+## [Unreleased]
+
+### Added
+- **Calendar entity** — Completed workouts now appear as calendar events in Home Assistant's calendar view, with exercise details and volume in the event description. Workouts are displayed as a training history; calendar trigger automations will not fire since workouts are logged after the fact
+
 ## [1.1.1] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Access via **Devices & Services** → **Hevy Workout Tracker** → **Configure**
 - **Routine Rotation** — Automatically detects the next workout in your A/B/C rotation
 - **30-Day History** — Service call for full workout history with enriched data
 - **Automatic Updates** — Configurable polling interval (5–120 minutes)
+- **Calendar Entity** — Completed workouts appear on the HA calendar with exercise details, volume, and duration. This is a history view (workouts are logged after the fact), not an automation trigger source
 - **Unit Support** — Imperial (lbs) or metric (kg)
 
 ---

--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -23,7 +23,7 @@ from .services import async_register_services, async_unregister_services
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CALENDAR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/hevy/calendar.py
+++ b/custom_components/hevy/calendar.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 import hashlib
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.components.calendar import (

--- a/custom_components/hevy/calendar.py
+++ b/custom_components/hevy/calendar.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 import hashlib
-import logging
 from typing import Any
 
 from homeassistant.components.calendar import (
@@ -19,8 +18,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_API_KEY, DOMAIN
 from .coordinator import HevyDataUpdateCoordinator
 from .sensor import get_device_info
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -42,11 +39,18 @@ def _parse_dt(date_str: str | None) -> datetime | None:
         return None
 
 
-def _build_event_description(workout: dict[str, Any]) -> str | None:
+def _build_event_description(
+    workout: dict[str, Any],
+    coordinator: HevyDataUpdateCoordinator,
+) -> str | None:
     """Build a human-readable description from workout exercise data.
+
+    Uses the coordinator's unit conversion so volume matches the
+    configured unit system (imperial or metric).
 
     Args:
         workout: Raw workout dict from the Hevy API
+        coordinator: Coordinator with unit system config
 
     Returns:
         Formatted description string, or None if no exercises
@@ -55,6 +59,7 @@ def _build_event_description(workout: dict[str, Any]) -> str | None:
     if not exercises:
         return None
 
+    unit = coordinator._get_weight_unit()
     lines: list[str] = []
     for exercise in exercises:
         title = exercise.get("title", "Unknown")
@@ -68,12 +73,14 @@ def _build_event_description(workout: dict[str, Any]) -> str | None:
             weight_kg = s.get("weight_kg")
             reps = s.get("reps")
             if weight_kg is not None and reps is not None:
-                total_volume += weight_kg * reps
-                has_weight = True
+                converted = coordinator._convert_weight(weight_kg)
+                if converted is not None:
+                    total_volume += converted * reps
+                    has_weight = True
 
         if has_weight and total_volume > 0:
             lines.append(
-                f"{title}: {set_count} sets, {round(total_volume, 1)} kg volume"
+                f"{title}: {set_count} sets, {round(total_volume, 1)} {unit} volume"
             )
         else:
             lines.append(f"{title}: {set_count} sets")
@@ -81,11 +88,15 @@ def _build_event_description(workout: dict[str, Any]) -> str | None:
     return "\n".join(lines)
 
 
-def _workout_to_event(workout: dict[str, Any]) -> CalendarEvent | None:
+def _workout_to_event(
+    workout: dict[str, Any],
+    coordinator: HevyDataUpdateCoordinator,
+) -> CalendarEvent | None:
     """Convert a raw Hevy workout dict to a CalendarEvent.
 
     Args:
         workout: Raw workout dict from the Hevy API
+        coordinator: Coordinator with unit system config
 
     Returns:
         CalendarEvent instance, or None if start_time is missing or invalid
@@ -99,7 +110,7 @@ def _workout_to_event(workout: dict[str, Any]) -> CalendarEvent | None:
         end_dt = start_dt + timedelta(hours=1)
 
     title = workout.get("title") or "Workout"
-    description = _build_event_description(workout)
+    description = _build_event_description(workout, coordinator)
 
     return CalendarEvent(
         start=start_dt,
@@ -168,7 +179,7 @@ class HevyCalendarEntity(CoordinatorEntity[HevyDataUpdateCoordinator], CalendarE
             return None
 
         # Workouts are sorted most-recent-first
-        return _workout_to_event(workouts[0])
+        return _workout_to_event(workouts[0], self.coordinator)
 
     async def async_get_events(
         self,
@@ -176,10 +187,9 @@ class HevyCalendarEntity(CoordinatorEntity[HevyDataUpdateCoordinator], CalendarE
         start_date: datetime,
         end_date: datetime,
     ) -> list[CalendarEvent]:
-        """Return workout events within the given date range.
+        """Return workout events that overlap the given date range.
 
-        Called by HA when the calendar view queries for events, or when
-        external CalDAV clients request a sync.
+        Called by HA when the calendar view queries for events.
 
         Args:
             hass: Home Assistant instance
@@ -196,14 +206,11 @@ class HevyCalendarEntity(CoordinatorEntity[HevyDataUpdateCoordinator], CalendarE
 
         events: list[CalendarEvent] = []
         for workout in workouts:
-            start_dt = _parse_dt(workout.get("start_time"))
-            if start_dt is None:
+            event = _workout_to_event(workout, self.coordinator)
+            if event is None:
                 continue
-            # Filter to the requested range
-            if start_dt < start_date or start_dt >= end_date:
-                continue
-            event = _workout_to_event(workout)
-            if event is not None:
+            # Include events that overlap the requested range
+            if event.end > start_date and event.start < end_date:
                 events.append(event)
 
         events.sort(key=lambda e: e.start)

--- a/custom_components/hevy/calendar.py
+++ b/custom_components/hevy/calendar.py
@@ -1,0 +1,210 @@
+"""Calendar platform for Hevy Workout Tracker."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import hashlib
+import logging
+from typing import Any
+
+from homeassistant.components.calendar import (
+    CalendarEntity,
+    CalendarEvent,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_API_KEY, DOMAIN
+from .coordinator import HevyDataUpdateCoordinator
+from .sensor import get_device_info
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+def _parse_dt(date_str: str | None) -> datetime | None:
+    """Parse an ISO 8601 datetime string from the Hevy API.
+
+    Args:
+        date_str: ISO datetime string (e.g., "2026-01-15T10:30:00Z")
+
+    Returns:
+        Timezone-aware datetime, or None if parsing fails
+    """
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _build_event_description(workout: dict[str, Any]) -> str | None:
+    """Build a human-readable description from workout exercise data.
+
+    Args:
+        workout: Raw workout dict from the Hevy API
+
+    Returns:
+        Formatted description string, or None if no exercises
+    """
+    exercises = workout.get("exercises", [])
+    if not exercises:
+        return None
+
+    lines: list[str] = []
+    for exercise in exercises:
+        title = exercise.get("title", "Unknown")
+        sets = exercise.get("sets", [])
+        set_count = len(sets)
+
+        # Sum up volume for weighted exercises
+        total_volume = 0.0
+        has_weight = False
+        for s in sets:
+            weight_kg = s.get("weight_kg")
+            reps = s.get("reps")
+            if weight_kg is not None and reps is not None:
+                total_volume += weight_kg * reps
+                has_weight = True
+
+        if has_weight and total_volume > 0:
+            lines.append(
+                f"{title}: {set_count} sets, {round(total_volume, 1)} kg volume"
+            )
+        else:
+            lines.append(f"{title}: {set_count} sets")
+
+    return "\n".join(lines)
+
+
+def _workout_to_event(workout: dict[str, Any]) -> CalendarEvent | None:
+    """Convert a raw Hevy workout dict to a CalendarEvent.
+
+    Args:
+        workout: Raw workout dict from the Hevy API
+
+    Returns:
+        CalendarEvent instance, or None if start_time is missing or invalid
+    """
+    start_dt = _parse_dt(workout.get("start_time"))
+    if start_dt is None:
+        return None
+
+    end_dt = _parse_dt(workout.get("end_time"))
+    if end_dt is None:
+        end_dt = start_dt + timedelta(hours=1)
+
+    title = workout.get("title") or "Workout"
+    description = _build_event_description(workout)
+
+    return CalendarEvent(
+        start=start_dt,
+        end=end_dt,
+        summary=title,
+        description=description,
+        uid=workout.get("id"),
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hevy calendar entity.
+
+    Args:
+        hass: Home Assistant instance
+        entry: Config entry
+        async_add_entities: Callback to add entities
+    """
+    coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([HevyCalendarEntity(coordinator, entry)])
+
+
+class HevyCalendarEntity(CoordinatorEntity[HevyDataUpdateCoordinator], CalendarEntity):
+    """Calendar entity that displays Hevy workouts as calendar events."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(
+        self,
+        coordinator: HevyDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the calendar entity.
+
+        Args:
+            coordinator: Data coordinator with cached workout data
+            entry: Config entry for device info and unique ID
+        """
+        super().__init__(coordinator)
+        self._entry = entry
+
+        api_key = entry.data[CONF_API_KEY]
+        key_hash = hashlib.md5(api_key.encode()).hexdigest()[:8]
+        self._attr_unique_id = f"{key_hash}_workout_calendar"
+        self._attr_name = "Workout calendar"
+        self._attr_device_info = get_device_info(entry)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the most recent workout as the current event.
+
+        The coordinator caches 30 days of workout history (all past events).
+        There are no upcoming events since Hevy does not schedule future workouts.
+        This returns the latest workout so the calendar card always shows something.
+        """
+        if not self.coordinator.data:
+            return None
+
+        workouts: list[dict[str, Any]] = self.coordinator.data.get("workouts", [])
+        if not workouts:
+            return None
+
+        # Workouts are sorted most-recent-first
+        return _workout_to_event(workouts[0])
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return workout events within the given date range.
+
+        Called by HA when the calendar view queries for events, or when
+        external CalDAV clients request a sync.
+
+        Args:
+            hass: Home Assistant instance
+            start_date: Start of the query range (inclusive)
+            end_date: End of the query range (exclusive)
+
+        Returns:
+            List of CalendarEvents sorted by start time
+        """
+        if not self.coordinator.data:
+            return []
+
+        workouts: list[dict[str, Any]] = self.coordinator.data.get("workouts", [])
+
+        events: list[CalendarEvent] = []
+        for workout in workouts:
+            start_dt = _parse_dt(workout.get("start_time"))
+            if start_dt is None:
+                continue
+            # Filter to the requested range
+            if start_dt < start_date or start_dt >= end_date:
+                continue
+            event = _workout_to_event(workout)
+            if event is not None:
+                events.append(event)
+
+        events.sort(key=lambda e: e.start)
+        return events

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -6,14 +6,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.hevy.const import UNIT_SYSTEM_METRIC, UNIT_SYSTEM_IMPERIAL
 from custom_components.hevy.calendar import (
     HevyCalendarEntity,
     _build_event_description,
     _parse_dt,
     _workout_to_event,
 )
-
+from custom_components.hevy.const import UNIT_SYSTEM_IMPERIAL, UNIT_SYSTEM_METRIC
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,310 @@
+"""Tests for the Hevy calendar platform."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hevy.calendar import (
+    HevyCalendarEntity,
+    _build_event_description,
+    _parse_dt,
+    _workout_to_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_entry() -> MagicMock:
+    """Return a mock config entry."""
+    entry = MagicMock()
+    entry.data = {"api_key": "test_key_123"}
+    return entry
+
+
+@pytest.fixture
+def sample_workouts() -> list[dict]:
+    """Return sample workout data (most-recent-first, as coordinator stores)."""
+    return [
+        {
+            "id": "w1",
+            "title": "Push Day",
+            "start_time": "2026-07-17T10:30:00Z",
+            "end_time": "2026-07-17T11:15:00Z",
+            "exercises": [
+                {
+                    "title": "Bench Press",
+                    "sets": [
+                        {"weight_kg": 60, "reps": 10},
+                        {"weight_kg": 60, "reps": 8},
+                    ],
+                },
+            ],
+        },
+        {
+            "id": "w2",
+            "title": "Pull Day",
+            "start_time": "2026-07-15T08:00:00Z",
+            "end_time": "2026-07-15T09:00:00Z",
+            "exercises": [
+                {
+                    "title": "Deadlift",
+                    "sets": [{"weight_kg": 100, "reps": 5}],
+                },
+            ],
+        },
+        {
+            "id": "w3",
+            "title": "Leg Day",
+            "start_time": "2026-07-10T07:00:00Z",
+            "end_time": "2026-07-10T08:30:00Z",
+            "exercises": [
+                {
+                    "title": "Squat",
+                    "sets": [{"weight_kg": 80, "reps": 8}],
+                },
+            ],
+        },
+    ]
+
+
+@pytest.fixture
+def coordinator_with_data(
+    sample_workouts: list[dict],
+) -> MagicMock:
+    """Return a mock coordinator populated with sample workouts."""
+    coord = MagicMock()
+    coord.data = {"workouts": sample_workouts}
+    return coord
+
+
+@pytest.fixture
+def entity(
+    coordinator_with_data: MagicMock,
+    mock_entry: MagicMock,
+) -> HevyCalendarEntity:
+    """Return a HevyCalendarEntity with sample data."""
+    return HevyCalendarEntity(coordinator_with_data, mock_entry)
+
+
+# ---------------------------------------------------------------------------
+# _parse_dt
+# ---------------------------------------------------------------------------
+
+class TestParseDt:
+    """Tests for _parse_dt."""
+
+    def test_valid_iso(self) -> None:
+        dt = _parse_dt("2026-07-17T10:30:00Z")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.month == 7
+        assert dt.day == 17
+        assert dt.tzinfo is not None
+
+    def test_none_input(self) -> None:
+        assert _parse_dt(None) is None
+
+    def test_empty_string(self) -> None:
+        assert _parse_dt("") is None
+
+    def test_invalid_string(self) -> None:
+        assert _parse_dt("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# _build_event_description
+# ---------------------------------------------------------------------------
+
+class TestBuildEventDescription:
+    """Tests for _build_event_description."""
+
+    def test_weighted_exercises(self) -> None:
+        workout = {
+            "exercises": [
+                {
+                    "title": "Bench Press",
+                    "sets": [
+                        {"weight_kg": 60, "reps": 10},
+                        {"weight_kg": 60, "reps": 8},
+                    ],
+                },
+            ],
+        }
+        desc = _build_event_description(workout)
+        assert desc is not None
+        assert "Bench Press" in desc
+        assert "1080.0 kg volume" in desc  # 60*10 + 60*8
+
+    def test_bodyweight_exercises(self) -> None:
+        workout = {
+            "exercises": [
+                {"title": "Push-ups", "sets": [{"weight_kg": None, "reps": 20}]},
+            ],
+        }
+        desc = _build_event_description(workout)
+        assert desc is not None
+        assert "Push-ups" in desc
+        assert "1 sets" in desc
+        assert "kg volume" not in desc
+
+    def test_empty_exercises(self) -> None:
+        assert _build_event_description({"exercises": []}) is None
+
+    def test_no_exercises_key(self) -> None:
+        assert _build_event_description({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _workout_to_event
+# ---------------------------------------------------------------------------
+
+class TestWorkoutToEvent:
+    """Tests for _workout_to_event."""
+
+    def test_full_workout(self) -> None:
+        workout = {
+            "id": "abc123",
+            "title": "Push Day",
+            "start_time": "2026-07-17T10:30:00Z",
+            "end_time": "2026-07-17T11:15:00Z",
+            "exercises": [
+                {"title": "Bench Press", "sets": [{"weight_kg": 60, "reps": 10}]},
+            ],
+        }
+        event = _workout_to_event(workout)
+        assert event is not None
+        assert event.summary == "Push Day"
+        assert event.start.year == 2026
+        assert event.end.hour == 11
+        assert event.uid == "abc123"
+        assert event.description is not None
+        assert "Bench Press" in event.description
+
+    def test_missing_end_time_defaults_to_1hr(self) -> None:
+        workout = {
+            "id": "xyz",
+            "title": "Leg Day",
+            "start_time": "2026-07-15T08:00:00Z",
+        }
+        event = _workout_to_event(workout)
+        assert event is not None
+        duration = event.end - event.start
+        assert duration == timedelta(hours=1)
+
+    def test_missing_start_time(self) -> None:
+        assert _workout_to_event({"title": "No Time"}) is None
+
+    def test_fallback_title(self) -> None:
+        workout = {"start_time": "2026-07-17T10:30:00Z"}
+        event = _workout_to_event(workout)
+        assert event is not None
+        assert event.summary == "Workout"
+
+    def test_invalid_start_time(self) -> None:
+        assert _workout_to_event({"start_time": "bad"}) is None
+
+
+# ---------------------------------------------------------------------------
+# HevyCalendarEntity
+# ---------------------------------------------------------------------------
+
+class TestHevyCalendarEntityEvent:
+    """Tests for HevyCalendarEntity.event property."""
+
+    def test_event_returns_most_recent(
+        self, entity: HevyCalendarEntity
+    ) -> None:
+        event = entity.event
+        assert event is not None
+        assert event.summary == "Push Day"
+        assert event.uid == "w1"
+
+    def test_event_no_data(self, mock_entry: MagicMock) -> None:
+        coord = MagicMock()
+        coord.data = None
+        entity = HevyCalendarEntity(coord, mock_entry)
+        assert entity.event is None
+
+    def test_event_empty_workouts(self, mock_entry: MagicMock) -> None:
+        coord = MagicMock()
+        coord.data = {"workouts": []}
+        entity = HevyCalendarEntity(coord, mock_entry)
+        assert entity.event is None
+
+
+@pytest.mark.asyncio
+class TestHevyCalendarEntityGetEvents:
+    """Tests for HevyCalendarEntity.async_get_events."""
+
+    async def test_get_events_full_range(self, entity: HevyCalendarEntity) -> None:
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 7, 1, tzinfo=timezone.utc),
+            datetime(2026, 8, 1, tzinfo=timezone.utc),
+        )
+        assert len(events) == 3
+        # Should be sorted oldest-first
+        assert events[0].summary == "Leg Day"
+        assert events[1].summary == "Pull Day"
+        assert events[2].summary == "Push Day"
+
+    async def test_get_events_narrow_range(
+        self, entity: HevyCalendarEntity
+    ) -> None:
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 7, 14, tzinfo=timezone.utc),
+            datetime(2026, 7, 16, tzinfo=timezone.utc),
+        )
+        assert len(events) == 1
+        assert events[0].summary == "Pull Day"
+
+    async def test_get_events_empty_range(
+        self, entity: HevyCalendarEntity
+    ) -> None:
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 8, 1, tzinfo=timezone.utc),
+            datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+        assert len(events) == 0
+
+    async def test_get_events_no_data(self, mock_entry: MagicMock) -> None:
+        coord = MagicMock()
+        coord.data = None
+        entity = HevyCalendarEntity(coord, mock_entry)
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 7, 1, tzinfo=timezone.utc),
+            datetime(2026, 8, 1, tzinfo=timezone.utc),
+        )
+        assert len(events) == 0
+
+    async def test_get_events_skips_missing_start_time(
+        self, mock_entry: MagicMock
+    ) -> None:
+        workouts = [
+            {"id": "bad", "title": "No Time", "exercises": []},
+            {
+                "id": "w1",
+                "title": "Push Day",
+                "start_time": "2026-07-17T10:30:00Z",
+                "end_time": "2026-07-17T11:15:00Z",
+                "exercises": [],
+            },
+        ]
+        coord = MagicMock()
+        coord.data = {"workouts": workouts}
+        entity = HevyCalendarEntity(coord, mock_entry)
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 1, 1, tzinfo=timezone.utc),
+            datetime(2026, 12, 31, tzinfo=timezone.utc),
+        )
+        assert len(events) == 1
+        assert events[0].summary == "Push Day"

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.hevy.const import UNIT_SYSTEM_METRIC, UNIT_SYSTEM_IMPERIAL
 from custom_components.hevy.calendar import (
     HevyCalendarEntity,
     _build_event_description,
@@ -24,6 +25,28 @@ def mock_entry() -> MagicMock:
     entry = MagicMock()
     entry.data = {"api_key": "test_key_123"}
     return entry
+
+
+@pytest.fixture
+def coordinator_imperial() -> MagicMock:
+    """Return a mock coordinator with imperial unit system."""
+    coord = MagicMock()
+    coord.unit_system = UNIT_SYSTEM_IMPERIAL
+    coord._get_weight_unit.return_value = "lbs"
+    # Imperial: 60 kg -> 132.5 lbs (60 * 2.20462 = 132.2772, rounded to 132.5)
+    coord._convert_weight.side_effect = lambda kg: round(kg * 2.20462 * 2) / 2 if kg is not None else None
+    return coord
+
+
+@pytest.fixture
+def coordinator_metric() -> MagicMock:
+    """Return a mock coordinator with metric unit system."""
+    coord = MagicMock()
+    coord.unit_system = UNIT_SYSTEM_METRIC
+    coord._get_weight_unit.return_value = "kg"
+    # Metric: round kg to nearest 0.5
+    coord._convert_weight.side_effect = lambda kg: round(kg * 2) / 2 if kg is not None else None
+    return coord
 
 
 @pytest.fixture
@@ -75,11 +98,11 @@ def sample_workouts() -> list[dict]:
 @pytest.fixture
 def coordinator_with_data(
     sample_workouts: list[dict],
+    coordinator_imperial: MagicMock,
 ) -> MagicMock:
     """Return a mock coordinator populated with sample workouts."""
-    coord = MagicMock()
-    coord.data = {"workouts": sample_workouts}
-    return coord
+    coordinator_imperial.data = {"workouts": sample_workouts}
+    return coordinator_imperial
 
 
 @pytest.fixture
@@ -123,7 +146,9 @@ class TestParseDt:
 class TestBuildEventDescription:
     """Tests for _build_event_description."""
 
-    def test_weighted_exercises(self) -> None:
+    def test_weighted_exercises_imperial(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
         workout = {
             "exercises": [
                 {
@@ -135,28 +160,55 @@ class TestBuildEventDescription:
                 },
             ],
         }
-        desc = _build_event_description(workout)
+        desc = _build_event_description(workout, coordinator_imperial)
         assert desc is not None
         assert "Bench Press" in desc
-        assert "1080.0 kg volume" in desc  # 60*10 + 60*8
+        # 60kg -> 132.5 lbs; 132.5 * 10 + 132.5 * 8 = 2385.0
+        assert "2385.0 lbs volume" in desc
 
-    def test_bodyweight_exercises(self) -> None:
+    def test_weighted_exercises_metric(
+        self, coordinator_metric: MagicMock
+    ) -> None:
+        workout = {
+            "exercises": [
+                {
+                    "title": "Bench Press",
+                    "sets": [
+                        {"weight_kg": 60, "reps": 10},
+                        {"weight_kg": 60, "reps": 8},
+                    ],
+                },
+            ],
+        }
+        desc = _build_event_description(workout, coordinator_metric)
+        assert desc is not None
+        assert "Bench Press" in desc
+        # 60kg rounded to 60.0; 60.0 * 10 + 60.0 * 8 = 1080.0
+        assert "1080.0 kg volume" in desc
+
+    def test_bodyweight_exercises(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
         workout = {
             "exercises": [
                 {"title": "Push-ups", "sets": [{"weight_kg": None, "reps": 20}]},
             ],
         }
-        desc = _build_event_description(workout)
+        desc = _build_event_description(workout, coordinator_imperial)
         assert desc is not None
         assert "Push-ups" in desc
         assert "1 sets" in desc
-        assert "kg volume" not in desc
+        assert "lbs volume" not in desc
 
-    def test_empty_exercises(self) -> None:
-        assert _build_event_description({"exercises": []}) is None
+    def test_empty_exercises(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
+        assert _build_event_description({"exercises": []}, coordinator_imperial) is None
 
-    def test_no_exercises_key(self) -> None:
-        assert _build_event_description({}) is None
+    def test_no_exercises_key(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
+        assert _build_event_description({}, coordinator_imperial) is None
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +218,7 @@ class TestBuildEventDescription:
 class TestWorkoutToEvent:
     """Tests for _workout_to_event."""
 
-    def test_full_workout(self) -> None:
+    def test_full_workout(self, coordinator_imperial: MagicMock) -> None:
         workout = {
             "id": "abc123",
             "title": "Push Day",
@@ -176,7 +228,7 @@ class TestWorkoutToEvent:
                 {"title": "Bench Press", "sets": [{"weight_kg": 60, "reps": 10}]},
             ],
         }
-        event = _workout_to_event(workout)
+        event = _workout_to_event(workout, coordinator_imperial)
         assert event is not None
         assert event.summary == "Push Day"
         assert event.start.year == 2026
@@ -185,28 +237,36 @@ class TestWorkoutToEvent:
         assert event.description is not None
         assert "Bench Press" in event.description
 
-    def test_missing_end_time_defaults_to_1hr(self) -> None:
+    def test_missing_end_time_defaults_to_1hr(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
         workout = {
             "id": "xyz",
             "title": "Leg Day",
             "start_time": "2026-07-15T08:00:00Z",
         }
-        event = _workout_to_event(workout)
+        event = _workout_to_event(workout, coordinator_imperial)
         assert event is not None
         duration = event.end - event.start
         assert duration == timedelta(hours=1)
 
-    def test_missing_start_time(self) -> None:
-        assert _workout_to_event({"title": "No Time"}) is None
+    def test_missing_start_time(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
+        assert _workout_to_event({"title": "No Time"}, coordinator_imperial) is None
 
-    def test_fallback_title(self) -> None:
+    def test_fallback_title(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
         workout = {"start_time": "2026-07-17T10:30:00Z"}
-        event = _workout_to_event(workout)
+        event = _workout_to_event(workout, coordinator_imperial)
         assert event is not None
         assert event.summary == "Workout"
 
-    def test_invalid_start_time(self) -> None:
-        assert _workout_to_event({"start_time": "bad"}) is None
+    def test_invalid_start_time(
+        self, coordinator_imperial: MagicMock
+    ) -> None:
+        assert _workout_to_event({"start_time": "bad"}, coordinator_imperial) is None
 
 
 # ---------------------------------------------------------------------------
@@ -224,16 +284,14 @@ class TestHevyCalendarEntityEvent:
         assert event.summary == "Push Day"
         assert event.uid == "w1"
 
-    def test_event_no_data(self, mock_entry: MagicMock) -> None:
-        coord = MagicMock()
-        coord.data = None
-        entity = HevyCalendarEntity(coord, mock_entry)
+    def test_event_no_data(self, mock_entry: MagicMock, coordinator_imperial: MagicMock) -> None:
+        coordinator_imperial.data = None
+        entity = HevyCalendarEntity(coordinator_imperial, mock_entry)
         assert entity.event is None
 
-    def test_event_empty_workouts(self, mock_entry: MagicMock) -> None:
-        coord = MagicMock()
-        coord.data = {"workouts": []}
-        entity = HevyCalendarEntity(coord, mock_entry)
+    def test_event_empty_workouts(self, mock_entry: MagicMock, coordinator_imperial: MagicMock) -> None:
+        coordinator_imperial.data = {"workouts": []}
+        entity = HevyCalendarEntity(coordinator_imperial, mock_entry)
         assert entity.event is None
 
 
@@ -264,6 +322,29 @@ class TestHevyCalendarEntityGetEvents:
         assert len(events) == 1
         assert events[0].summary == "Pull Day"
 
+    async def test_get_events_overlap_includes_crossing_event(
+        self, mock_entry: MagicMock, coordinator_imperial: MagicMock
+    ) -> None:
+        """An event that starts before the range but ends inside it should be included."""
+        workouts = [
+            {
+                "id": "crossing",
+                "title": "Late Night Workout",
+                "start_time": "2026-07-13T23:00:00Z",
+                "end_time": "2026-07-14T01:00:00Z",
+                "exercises": [],
+            },
+        ]
+        coordinator_imperial.data = {"workouts": workouts}
+        entity = HevyCalendarEntity(coordinator_imperial, mock_entry)
+        events = await entity.async_get_events(
+            None,
+            datetime(2026, 7, 14, tzinfo=timezone.utc),
+            datetime(2026, 7, 16, tzinfo=timezone.utc),
+        )
+        assert len(events) == 1
+        assert events[0].summary == "Late Night Workout"
+
     async def test_get_events_empty_range(
         self, entity: HevyCalendarEntity
     ) -> None:
@@ -274,10 +355,9 @@ class TestHevyCalendarEntityGetEvents:
         )
         assert len(events) == 0
 
-    async def test_get_events_no_data(self, mock_entry: MagicMock) -> None:
-        coord = MagicMock()
-        coord.data = None
-        entity = HevyCalendarEntity(coord, mock_entry)
+    async def test_get_events_no_data(self, mock_entry: MagicMock, coordinator_imperial: MagicMock) -> None:
+        coordinator_imperial.data = None
+        entity = HevyCalendarEntity(coordinator_imperial, mock_entry)
         events = await entity.async_get_events(
             None,
             datetime(2026, 7, 1, tzinfo=timezone.utc),
@@ -286,7 +366,7 @@ class TestHevyCalendarEntityGetEvents:
         assert len(events) == 0
 
     async def test_get_events_skips_missing_start_time(
-        self, mock_entry: MagicMock
+        self, mock_entry: MagicMock, coordinator_imperial: MagicMock
     ) -> None:
         workouts = [
             {"id": "bad", "title": "No Time", "exercises": []},
@@ -298,9 +378,8 @@ class TestHevyCalendarEntityGetEvents:
                 "exercises": [],
             },
         ]
-        coord = MagicMock()
-        coord.data = {"workouts": workouts}
-        entity = HevyCalendarEntity(coord, mock_entry)
+        coordinator_imperial.data = {"workouts": workouts}
+        entity = HevyCalendarEntity(coordinator_imperial, mock_entry)
         events = await entity.async_get_events(
             None,
             datetime(2026, 1, 1, tzinfo=timezone.utc),


### PR DESCRIPTION
Adds HevyCalendarEntity that displays completed workouts as HA calendar events. Workouts appear with their title as summary, exercise details in the description, and start/end times from the Hevy API.

- New calendar.py platform with HevyCalendarEntity(CalendarEntity)
- async_get_events() for date-range queries (calendar view, CalDAV sync)
- event property returns most recent workout
- Registers Platform.CALENDAR in __init__.py
- 21 unit tests covering parsing, event building, and entity behavior
