### PR TITLE
fix: resolve ruff 0.16.0 lint errors and align CI ruff versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: "actions/checkout@v7"
       - uses: "astral-sh/ruff-action@v3"
+        with:
+          version-file: "requirements-test.txt"
 
   validate-hassfest:
     runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI workflow (`.github/workflows/ci.yml`) running ruff lint and pytest on every push and pull request
 - Dependabot updates for pip test dependencies
 
+### Changed
+- Code cleanup for ruff 0.16.0 (import sorting, `Self` return type on `__aenter__`, narrowed exception handling in coordinator fetches, simplified conditionals)
+- Validate workflow now reads its ruff version from `requirements-test.txt` so both CI workflows lint with the same pinned version
+
 ## [1.1.1] - 2026-03-14
 
 ### Added

--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -1,8 +1,8 @@
 """The Hevy Workout Tracker integration."""
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform

--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Self
 
 import aiohttp
 
@@ -34,13 +34,13 @@ class HevyApiClient:
         self._session = session
         self._own_session = session is None
 
-    async def __aenter__(self) -> HevyApiClient:
+    async def __aenter__(self) -> Self:
         """Async enter."""
         if self._own_session:
             self._session = aiohttp.ClientSession()
         return self
 
-    async def __aexit__(self, *args: Any) -> None:
+    async def __aexit__(self, *args: object) -> None:
         """Async exit."""
         if self._own_session and self._session:
             await self._session.close()

--- a/custom_components/hevy/config_flow.py
+++ b/custom_components/hevy/config_flow.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -1,8 +1,8 @@
 """Data Update Coordinator for Hevy integration."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -94,7 +94,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.info(
                 "Cached %d exercise templates from %d pages", total_templates, page
             )
-        except Exception as err:
+        except HevyApiError as err:
             _LOGGER.warning("Failed to fetch exercise templates: %s", err)
 
     async def fetch_routines(self) -> None:
@@ -117,7 +117,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "exercises": exercises,
                     })
             _LOGGER.info("Cached %d routines", len(self._routines))
-        except Exception as err:
+        except HevyApiError as err:
             _LOGGER.warning("Failed to fetch routines: %s", err)
 
     async def _fetch_30_day_workouts(self) -> list[dict[str, Any]]:
@@ -264,9 +264,11 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 primary = template.get("muscle_group")
                 secondaries = template.get("secondary_muscle_groups", [])
 
-                if primary:
-                    if primary not in muscle_last_trained or workout_dt > muscle_last_trained[primary]:
-                        muscle_last_trained[primary] = workout_dt
+                if primary and (
+                    primary not in muscle_last_trained
+                    or workout_dt > muscle_last_trained[primary]
+                ):
+                    muscle_last_trained[primary] = workout_dt
                 for sec in secondaries:
                     if sec not in muscle_last_trained or workout_dt > muscle_last_trained[sec]:
                         muscle_last_trained[sec] = workout_dt
@@ -667,17 +669,15 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
                     # Track PR for distance exercises (store in meters)
                     distance_meters = set_data.get("distance_meters")
-                    if distance_meters is not None:
-                        if exercise_title not in self._exercise_distance_prs:
-                            self._exercise_distance_prs[exercise_title] = {
-                                "distance_meters": distance_meters,
-                                "template_id": template_id,
-                            }
-                        elif distance_meters > self._exercise_distance_prs[exercise_title]["distance_meters"]:
-                            self._exercise_distance_prs[exercise_title] = {
-                                "distance_meters": distance_meters,
-                                "template_id": template_id,
-                            }
+                    if distance_meters is not None and (
+                        exercise_title not in self._exercise_distance_prs
+                        or distance_meters
+                        > self._exercise_distance_prs[exercise_title]["distance_meters"]
+                    ):
+                        self._exercise_distance_prs[exercise_title] = {
+                            "distance_meters": distance_meters,
+                            "template_id": template_id,
+                        }
 
     def _calculate_current_streak(self, workouts: list[dict[str, Any]]) -> int:
         """Calculate current workout streak (consecutive days with workouts).

--- a/custom_components/hevy/sensor.py
+++ b/custom_components/hevy/sensor.py
@@ -1,9 +1,9 @@
 """Sensor platform for Hevy Workout Tracker."""
 from __future__ import annotations
 
-from datetime import datetime
 import hashlib
 import logging
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -67,7 +67,7 @@ async def async_setup_entry(
     # Create per-exercise sensors dynamically
     if coordinator.data:
         exercise_data = coordinator.data.get("exercise_data", {})
-        for exercise_key, exercise_info in exercise_data.items():
+        for exercise_key in exercise_data:
             entities.append(HevyExerciseSensor(coordinator, entry, exercise_key))
 
     # Seed tracking set with initial exercises

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -1,13 +1,17 @@
 """Service handlers for the Hevy Workout Tracker integration."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 from typing import Any
 
 import voluptuous as vol
-
-from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 pytest-homeassistant-custom-component==0.13.346
-ruff==0.15.22
+ruff==0.16.0


### PR DESCRIPTION
## Summary
- Last night's scheduled Validate run went red when ruff-action floated to the new ruff 0.16.0 release, which expanded the default rule set. Nothing on main had changed. This also blocks #9, which fails lint on these same pre-existing findings.
- Fixes all 12 findings: import block sorting (I001), `Self` return type on `__aenter__` (PYI034), `object` annotation on `__aexit__` star-args (PYI036), blind `except Exception` narrowed to `HevyApiError` in the coordinator's best-effort fetches (BLE001), collapsed nested ifs (SIM102/SIM114), and keys-only dict iteration (PERF102).
- Bumps the ruff pin in requirements-test.txt to 0.16.0 and points ruff-action at that file via `version-file`, so the Validate and CI workflows always lint with the same pinned version. Dependabot bumps the pin, and future ruff releases can't break CI overnight again.
- No behavior changes. The exception narrowing is safe: the API client wraps timeouts, HTTP errors, and aiohttp failures into `HevyApiError` before they reach the coordinator.

## Test plan
- [x] `ruff check custom_components/hevy tests` clean with ruff 0.16.0
- [x] `pytest -q` passes, 35/35