### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Hevy Workout Tracker integration will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-24
 
 ### Added
 - Automated test suite (`tests/`) built on `pytest-homeassistant-custom-component`, covering coordinator unit conversions, PR tracking, streak calculation, workout pagination, and full config entry setup/unload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code cleanup for ruff 0.16.0 (import sorting, `Self` return type on `__aenter__`, narrowed exception handling in coordinator fetches, simplified conditionals)
 - Validate workflow now reads its ruff version from `requirements-test.txt` so both CI workflows lint with the same pinned version
 
+## [1.1.2] - 2026-03-16
+
+### Added
+- Weekly distance grid example dashboard card in the README
+- Ruff linting in the Validate workflow
+- Dependabot updates for GitHub Actions
+
+### Changed
+- Bumped actions/checkout to v6 for Node.js 24 compatibility
+
 ## [1.1.1] - 2026-03-14
 
 ### Added

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DisplacedForest/ha-hevy-tracker/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.1.1"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
## Summary
- Bump manifest version to 1.2.0
- Date the changelog: [Unreleased] becomes [1.2.0] - 2026-07-24 (calendar entity, test suite + CI, ruff 0.16.0 cleanup)

## Test plan
- [x] CI lint and tests