### PR TITLE
chore: add contribution templates, PR labeling, and release guards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DisplacedForest

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Something isn't working with the integration
+labels: ["bug"]
+body:
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      placeholder: "2026.7.1"
+    validations:
+      required: true
+  - type: input
+    id: integration-version
+    attributes:
+      label: Integration version
+      description: Found under Settings > Devices & Services > Hevy Workout Tracker, or in HACS
+      placeholder: "1.2.0"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug logs
+      description: |
+        Enable debug logging under Settings > Devices & Services > Hevy Workout Tracker > Enable debug logging, reproduce the issue, then paste the relevant log lines here. Remove your API key if it appears anywhere.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea for the integration
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: Describe what you're trying to do that the integration doesn't support today
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What you'd like to see
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds or alternatives you've considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What and why
+
+<!-- A sentence or two on what this changes and the problem it solves -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] CHANGELOG.md entry added under [Unreleased]
+- [ ] README updated, or no user-facing change

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file: "tests/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+integration:
+  - changed-files:
+      - any-glob-to-any-file: "custom_components/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,21 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Check manifest version matches tag
+        run: |
+          manifest=$(jq -r .version custom_components/hevy/manifest.json)
+          if [ "$manifest" != "${{ steps.version.outputs.version }}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match manifest version ${manifest}. Bump manifest.json before tagging."
+            exit 1
+          fi
+
+      - name: Check changelog has entry for version
+        run: |
+          if ! grep -q "^## \[${{ steps.version.outputs.version }}\]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no entry for ${{ steps.version.outputs.version }}."
+            exit 1
+          fi
+
       - name: Extract release notes from CHANGELOG
         id: notes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Hevy Workout Tracker integration will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Issue templates for bug reports and feature requests
+- Pull request template with a tests, changelog, and docs checklist
+- CODEOWNERS so pull requests automatically request maintainer review
+- Path-based PR labeling (documentation, tests, ci, integration)
+- Release workflow guards: a release now fails if the tag does not match `manifest.json` or `CHANGELOG.md` has no entry for the version
+
 ## [1.2.0] - 2026-07-24
 
 ### Added


### PR DESCRIPTION
## Summary
- CODEOWNERS auto-requests maintainer review on every PR
- Issue forms for bugs (HA version, integration version, debug logs required) and feature requests, blank issues off
- PR template with a short checklist: tests, changelog entry, docs
- actions/labeler with path-based rules (documentation, tests, ci, integration); matching labels created in the repo
- Release guards: the release job now fails if the tag does not match manifest.json or CHANGELOG.md has no entry for the version, so the v1.1.2 manifest drift can't happen again

Repo settings flipped separately (not in this diff): squash-only merges, delete branch on merge.

## Test plan
- [x] CI lint and tests
- [ ] Labeler applies labels to this PR once the workflow is on main (it runs from the base branch, so it takes effect on the next PR)