### PR TITLE
docs: note actions/labeler v7 bump in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Path-based PR labeling (documentation, tests, ci, integration)
 - Release workflow guards: a release now fails if the tag does not match `manifest.json` or `CHANGELOG.md` has no entry for the version
 
+### Changed
+- Bumped actions/labeler to v7 for Node.js 24 compatibility
+
 ## [1.2.0] - 2026-07-24
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds a Changed entry under Unreleased for the actions/labeler v5 to v7 bump merged in #15

The changelog already tracks tooling bumps this way (1.1.2 logged the actions/checkout v6 bump), and the release workflow guard needs the section to be accurate before the next tag.

## Test plan
- [ ] CI green (docs-only change, no code touched)