### PR TITLE
Add workout logging service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `hevy.log_workout` service that posts a completed workout to Hevy. Exercise names are resolved against the cached exercise catalog, weights and distances are converted from your configured unit system, and the service returns the new workout ID and title
 - Issue templates for bug reports and feature requests
 - Pull request template with a tests, changelog, and docs checklist
 - CODEOWNERS so pull requests automatically request maintainer review
@@ -42,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] - 2026-03-14
 
 ### Added
-- **Per-exercise weekly distance** - Cardio exercise sensors now expose `weekly_distance` and `weekly_distance_unit` attributes showing 7-day rolling distance totals per exercise (e.g., 10 mi biking, 6 mi running — separately)
+- **Per-exercise weekly distance** - Cardio exercise sensors now expose `weekly_distance` and `weekly_distance_unit` attributes showing 7-day rolling distance totals per exercise (e.g., 10 mi biking, 6 mi running, tracked separately)
 
 ### Changed
 - Reuse computed weekly distance data instead of calling `_calculate_weekly_distance()` twice per update cycle
@@ -83,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2026-03-09
 
 ### Fixed
-- Use Home Assistant's configured timezone for all date-based metrics (worked_out_today, streak, workout_days) instead of naive UTC date extraction — fixes incorrect values for users far from UTC (#3)
+- Use Home Assistant's configured timezone for all date-based metrics (worked_out_today, streak, workout_days) instead of naive UTC date extraction. Fixes incorrect values for users far from UTC (#3)
 
 ## [1.0.2] - 2026-02-26
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-blue?style=for-the-badge&logo=home-assistant)](https://www.home-assistant.io/)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/o7triud67l)
 
-A comprehensive Home Assistant integration for tracking your [Hevy](https://www.hevyapp.com/) workouts — with rich set-level sensor data, personal records, muscle recovery tracking, and dashboard-ready cards.
+A comprehensive Home Assistant integration for tracking your [Hevy](https://www.hevyapp.com/) workouts, with rich set-level sensor data, personal records, muscle recovery tracking, and dashboard-ready cards.
 
 > **Note:** A [Hevy Pro](https://www.hevyapp.com/pro) subscription is required to access the Hevy API.
 
@@ -56,16 +56,17 @@ Access via **Devices & Services** → **Hevy Workout Tracker** → **Configure**
 
 ## Features
 
-- **Rich Workout Data** — Full set-level detail with weight, reps, and duration tracking
-- **Summary Sensors** — Workout count, streaks, and weekly activity at a glance
-- **Per-Exercise Sensors** — Individual sensors for each exercise with personal records
-- **Muscle Group Tracking** — Which muscles you hit, which are due, days since last trained
-- **Weekly Volume Analysis** — Volume per muscle group with full exercise breakdown
-- **Routine Rotation** — Automatically detects the next workout in your A/B/C rotation
-- **30-Day History** — Service call for full workout history with enriched data
-- **Automatic Updates** — Configurable polling interval (5–120 minutes)
-- **Calendar Entity** — Completed workouts appear on the HA calendar with exercise details, volume, and duration. This is a history view (workouts are logged after the fact), not an automation trigger source
-- **Unit Support** — Imperial (lbs) or metric (kg)
+- **Rich Workout Data**: Full set-level detail with weight, reps, and duration tracking
+- **Summary Sensors**: Workout count, streaks, and weekly activity at a glance
+- **Per-Exercise Sensors**: Individual sensors for each exercise with personal records
+- **Muscle Group Tracking**: Which muscles you hit, which are due, days since last trained
+- **Weekly Volume Analysis**: Volume per muscle group with full exercise breakdown
+- **Routine Rotation**: Automatically detects the next workout in your A/B/C rotation
+- **30-Day History**: Service call for full workout history with enriched data
+- **Workout Logging**: Service call that posts a completed workout back to Hevy, in your configured units
+- **Automatic Updates**: Configurable polling interval (5–120 minutes)
+- **Calendar Entity**: Completed workouts appear on the HA calendar with exercise details, volume, and duration. This is a history view (workouts are logged after the fact), not an automation trigger source
+- **Unit Support**: Imperial (lbs) or metric (kg)
 
 ---
 
@@ -684,7 +685,7 @@ styles:
 Dynamically created for each unique exercise in your history.
 
 **Example:** `sensor.hevy_bench_press_dumbbell`
-**State:** Best set — e.g., `35 lbs × 12` or `60s`
+**State:** Best set, e.g. `35 lbs × 12` or `60s`
 
 | Attribute | Description |
 |-----------|-------------|
@@ -708,12 +709,12 @@ Returns enriched workout history for a specified number of days. Call via **Deve
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `config_entry_id` | Yes | — | The Hevy integration config entry ID |
+| `config_entry_id` | Yes | none | The Hevy integration config entry ID |
 | `days` | No | 30 | Number of days of history (1–90) |
 
 **Response includes:**
-- `summary` — Total workouts, total volume, workout days, avg duration, avg volume per workout
-- `workouts` — Array of workouts with full exercise/set detail, muscle groups, and duration
+- `summary`: Total workouts, total volume, workout days, avg duration, avg volume per workout
+- `workouts`: Array of workouts with full exercise/set detail, muscle groups, and duration
 
 <details>
 <summary><b>Example automation using service response</b></summary>
@@ -728,6 +729,73 @@ action:
   - service: notify.mobile_app
     data:
       message: "This week: {{ history.summary.total_workouts }} workouts, {{ history.summary.total_volume }} lbs total volume"
+```
+
+</details>
+
+### `hevy.log_workout`
+
+Posts a completed workout to Hevy. Exercise names are matched against your Hevy exercise catalog (exact first, then case-insensitive), and weights and distances are sent in the unit system configured for the integration. If any exercise name cannot be matched, nothing is posted and the error lists the closest names.
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `config_entry_id` | Yes | none | The Hevy integration config entry ID |
+| `title` | Yes | none | Name of the workout |
+| `exercises` | Yes | none | List of exercises, each with a `name`, optional `notes`, and one or more `sets` |
+| `start_time` | No | End time minus duration | When the workout started |
+| `end_time` | No | Now | When the workout ended |
+| `duration_minutes` | No | none | Workout length, used to derive the start time |
+| `description` | No | none | Workout notes |
+| `is_private` | No | false | Hide the workout from your Hevy followers |
+
+Each set takes an optional `type` (`warmup`, `normal`, `failure`, `dropset`, defaulting to `normal`), an optional `rpe` (6, 7, 7.5, 8, 8.5, 9, 9.5, 10), and at least one of `weight`, `reps`, `duration_seconds`, or `distance`.
+
+**Response includes:**
+- `workout_id`: The ID Hevy assigned to the new workout
+- `title`: The title Hevy stored
+
+<details>
+<summary><b>Example script logging a workout from a dashboard button</b></summary>
+
+```yaml
+script:
+  log_quick_push:
+    alias: "Log Quick Push Workout"
+    sequence:
+      - service: hevy.log_workout
+        data:
+          config_entry_id: YOUR_CONFIG_ENTRY_ID
+          title: "Quick Push"
+          duration_minutes: 40
+          exercises:
+            - name: "Bench Press"
+              notes: "Felt strong"
+              sets:
+                - type: warmup
+                  weight: 135
+                  reps: 8
+                - weight: 225
+                  reps: 5
+                  rpe: 9
+            - name: "Triceps Pushdown"
+              sets:
+                - weight: 60
+                  reps: 12
+        response_variable: logged
+      - service: notify.mobile_app
+        data:
+          message: "Logged {{ logged.title }} to Hevy"
+```
+
+Add it to a dashboard with a button card:
+
+```yaml
+type: button
+name: Log Quick Push
+icon: mdi:dumbbell
+tap_action:
+  action: call-service
+  service: script.log_quick_push
 ```
 
 </details>
@@ -875,7 +943,7 @@ exercises_preview:
 </details>
 
 <details>
-<summary><b>Last Workout Date — <code>workout_summaries</code> attribute</b></summary>
+<summary><b>Last Workout Date: <code>workout_summaries</code> attribute</b></summary>
 
 The `workout_summaries` attribute on `sensor.hevy_last_workout_date` provides a date-keyed dict of the last 30 days of workouts, useful for powering calendar cards.
 
@@ -934,4 +1002,4 @@ If multiple workouts fall on the same date, only the most recent is included.
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ action:
 
 Posts a completed workout to Hevy. Exercise names are matched against your Hevy exercise catalog (exact first, then case-insensitive), and weights and distances are sent in the unit system configured for the integration. If any exercise name cannot be matched, nothing is posted and the error lists the closest names.
 
-> **Warning:** Hevy has no way to delete a workout, in the app or the API. Anything this service logs is permanent. Workouts can be edited afterward but never removed, so give any dashboard button that calls this service a confirmation step.
+> **Warning:** The Hevy API has no delete, and the web app doesn't either. A mistakenly logged workout can only be removed in the Hevy mobile app, so give any dashboard button that calls this service a confirmation step.
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -737,6 +737,8 @@ action:
 
 Posts a completed workout to Hevy. Exercise names are matched against your Hevy exercise catalog (exact first, then case-insensitive), and weights and distances are sent in the unit system configured for the integration. If any exercise name cannot be matched, nothing is posted and the error lists the closest names.
 
+> **Warning:** Hevy has no way to delete a workout, in the app or the API. Anything this service logs is permanent. Workouts can be edited afterward but never removed, so give any dashboard button that calls this service a confirmation step.
+
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `config_entry_id` | Yes | none | The Hevy integration config entry ID |

--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -50,6 +50,7 @@ class HevyApiClient:
         method: str,
         endpoint: str,
         params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Make an API request.
 
@@ -74,7 +75,7 @@ class HevyApiClient:
         try:
             async with asyncio.timeout(API_TIMEOUT):
                 async with self._session.request(
-                    method, url, headers=headers, params=params
+                    method, url, headers=headers, params=params, json=json
                 ) as response:
                     if response.status == 401:
                         raise HevyAuthError("Invalid API key")
@@ -135,6 +136,9 @@ class HevyApiClient:
         """
         params = {"page": page, "pageSize": page_size}
         return await self._request("GET", "/workouts", params=params)
+
+    async def create_workout(self, workout: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/workouts", json=workout)
 
     async def get_workout_events(
         self, page: int = 1, page_size: int = 10

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DisplacedForest/ha-hevy-tracker/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -347,6 +347,8 @@ def async_register_services(hass: HomeAssistant) -> None:
         await coordinator.async_request_refresh()
 
         result = created.get("workout", created) if created else {}
+        if isinstance(result, list):
+            result = result[0] if result else {}
         _LOGGER.debug("Logged workout %s", result.get("id"))
 
         return {

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -12,15 +12,29 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .api import HevyApiError
+from .const import (
+    DOMAIN,
+    KG_TO_LBS,
+    METERS_TO_KM,
+    METERS_TO_MILES,
+    UNIT_SYSTEM_METRIC,
+)
 from .coordinator import HevyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_GET_WORKOUT_HISTORY = "get_workout_history"
+SERVICE_LOG_WORKOUT = "log_workout"
+
+SET_TYPES = ["warmup", "normal", "failure", "dropset"]
+RPE_VALUES = [6, 7, 7.5, 8, 8.5, 9, 9.5, 10]
+MEASUREMENT_FIELDS = ("weight", "reps", "duration_seconds", "distance")
+MAX_NAME_SUGGESTIONS = 3
 
 WORKOUT_HISTORY_SCHEMA = vol.Schema(
     {
@@ -30,6 +44,106 @@ WORKOUT_HISTORY_SCHEMA = vol.Schema(
         ),
     }
 )
+
+
+def _set_has_measurement(value: dict[str, Any]) -> dict[str, Any]:
+    if not any(value.get(field) is not None for field in MEASUREMENT_FIELDS):
+        raise vol.Invalid(
+            "Each set needs at least one of weight, reps, duration_seconds, "
+            "or distance"
+        )
+    return value
+
+
+SET_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional("type", default="normal"): vol.In(SET_TYPES),
+            vol.Optional("weight"): vol.Coerce(float),
+            vol.Optional("reps"): vol.Coerce(int),
+            vol.Optional("duration_seconds"): vol.Coerce(int),
+            vol.Optional("distance"): vol.Coerce(float),
+            vol.Optional("rpe"): vol.In(RPE_VALUES),
+        }
+    ),
+    _set_has_measurement,
+)
+
+EXERCISE_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): cv.string,
+        vol.Optional("notes"): cv.string,
+        vol.Required("sets"): vol.All(
+            cv.ensure_list, vol.Length(min=1), [SET_SCHEMA]
+        ),
+    }
+)
+
+LOG_WORKOUT_SCHEMA = vol.Schema(
+    {
+        vol.Required("config_entry_id"): cv.string,
+        vol.Required("title"): cv.string,
+        vol.Required("exercises"): vol.All(
+            cv.ensure_list, vol.Length(min=1), [EXERCISE_SCHEMA]
+        ),
+        vol.Optional("start_time"): cv.datetime,
+        vol.Optional("end_time"): cv.datetime,
+        vol.Optional("duration_minutes"): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
+        vol.Optional("description"): cv.string,
+        vol.Optional("is_private", default=False): cv.boolean,
+    }
+)
+
+
+def _to_kg(
+    coordinator: HevyDataUpdateCoordinator, weight: float | None
+) -> float | None:
+    if weight is None:
+        return None
+    if coordinator.unit_system == UNIT_SYSTEM_METRIC:
+        return float(weight)
+    return round(weight / KG_TO_LBS, 2)
+
+
+def _to_meters(
+    coordinator: HevyDataUpdateCoordinator, distance: float | None
+) -> int | None:
+    if distance is None:
+        return None
+    if coordinator.unit_system == UNIT_SYSTEM_METRIC:
+        return round(distance / METERS_TO_KM)
+    return round(distance / METERS_TO_MILES)
+
+
+def _resolve_template_id(
+    coordinator: HevyDataUpdateCoordinator, name: str
+) -> str:
+    templates = coordinator._exercise_templates
+
+    for template_id, template in templates.items():
+        if template.get("title") == name:
+            return template_id
+
+    lowered = name.lower()
+    for template_id, template in templates.items():
+        title = template.get("title")
+        if title and title.lower() == lowered:
+            return template_id
+
+    near_misses: list[str] = []
+    for template in templates.values():
+        title = template.get("title")
+        if title and lowered in title.lower():
+            near_misses.append(title)
+        if len(near_misses) == MAX_NAME_SUGGESTIONS:
+            break
+
+    message = f"Exercise '{name}' was not found in the Hevy exercise catalog"
+    if near_misses:
+        message = f"{message}. Did you mean: {', '.join(near_misses)}?"
+    raise HomeAssistantError(message)
 
 
 def async_register_services(hass: HomeAssistant) -> None:
@@ -174,6 +288,72 @@ def async_register_services(hass: HomeAssistant) -> None:
             "workouts": workouts_response,
         }
 
+    async def handle_log_workout(call: ServiceCall) -> ServiceResponse:
+        """Handle the log_workout service call."""
+        config_entry_id = call.data["config_entry_id"]
+
+        if config_entry_id not in hass.data.get(DOMAIN, {}):
+            raise ValueError(f"Config entry {config_entry_id} not found")
+
+        coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][config_entry_id]
+
+        exercises_payload: list[dict[str, Any]] = []
+        for exercise in call.data["exercises"]:
+            template_id = _resolve_template_id(coordinator, exercise["name"])
+
+            sets_payload: list[dict[str, Any]] = []
+            for set_data in exercise["sets"]:
+                sets_payload.append({
+                    "type": set_data["type"],
+                    "weight_kg": _to_kg(coordinator, set_data.get("weight")),
+                    "reps": set_data.get("reps"),
+                    "distance_meters": _to_meters(
+                        coordinator, set_data.get("distance")
+                    ),
+                    "duration_seconds": set_data.get("duration_seconds"),
+                    "rpe": set_data.get("rpe"),
+                })
+
+            exercises_payload.append({
+                "exercise_template_id": template_id,
+                "notes": exercise.get("notes"),
+                "sets": sets_payload,
+            })
+
+        end_time = call.data.get("end_time") or dt_util.now()
+        start_time = call.data.get("start_time")
+        if start_time is None:
+            duration_minutes = call.data.get("duration_minutes")
+            start_time = (
+                end_time - timedelta(minutes=duration_minutes)
+                if duration_minutes
+                else end_time
+            )
+
+        workout: dict[str, Any] = {"title": call.data["title"]}
+        description = call.data.get("description")
+        if description is not None:
+            workout["description"] = description
+        workout["is_private"] = call.data["is_private"]
+        workout["start_time"] = start_time.isoformat()
+        workout["end_time"] = end_time.isoformat()
+        workout["exercises"] = exercises_payload
+
+        try:
+            created = await coordinator.client.create_workout({"workout": workout})
+        except HevyApiError as err:
+            raise HomeAssistantError(str(err)) from err
+
+        await coordinator.async_request_refresh()
+
+        result = created.get("workout", created) if created else {}
+        _LOGGER.debug("Logged workout %s", result.get("id"))
+
+        return {
+            "workout_id": result.get("id"),
+            "title": result.get("title"),
+        }
+
     if not hass.services.has_service(DOMAIN, SERVICE_GET_WORKOUT_HISTORY):
         hass.services.async_register(
             DOMAIN,
@@ -183,8 +363,18 @@ def async_register_services(hass: HomeAssistant) -> None:
             supports_response=SupportsResponse.ONLY,
         )
 
+    if not hass.services.has_service(DOMAIN, SERVICE_LOG_WORKOUT):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_LOG_WORKOUT,
+            handle_log_workout,
+            schema=LOG_WORKOUT_SCHEMA,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
+
 
 def async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister Hevy services if no more config entries."""
     if not hass.data.get(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_GET_WORKOUT_HISTORY)
+        hass.services.async_remove(DOMAIN, SERVICE_LOG_WORKOUT)

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -22,7 +22,7 @@ get_workout_history:
 
 log_workout:
   name: Log workout
-  description: Posts a completed workout to Hevy with full exercise and set detail.
+  description: Posts a completed workout to Hevy with full exercise and set detail. Hevy has no delete, so logged workouts are permanent.
   fields:
     config_entry_id:
       name: Config entry ID

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -19,3 +19,65 @@ get_workout_history:
       selector:
         config_entry:
           integration: hevy
+
+log_workout:
+  name: Log workout
+  description: Posts a completed workout to Hevy with full exercise and set detail.
+  fields:
+    config_entry_id:
+      name: Config entry ID
+      description: The Hevy integration config entry ID
+      required: true
+      selector:
+        config_entry:
+          integration: hevy
+    title:
+      name: Title
+      description: Name of the workout
+      required: true
+      selector:
+        text:
+    exercises:
+      name: Exercises
+      description: >-
+        List of exercises. Each needs a name matching a Hevy exercise template
+        and at least one set. A set takes an optional type (warmup, normal,
+        failure, dropset), weight, reps, duration_seconds, distance, and rpe.
+        Weight and distance use the unit system configured for the integration.
+      required: true
+      selector:
+        object:
+    start_time:
+      name: Start time
+      description: When the workout started. Defaults to the end time minus the duration.
+      required: false
+      selector:
+        datetime:
+    end_time:
+      name: End time
+      description: When the workout ended. Defaults to now.
+      required: false
+      selector:
+        datetime:
+    duration_minutes:
+      name: Duration
+      description: Workout length in minutes, used to derive the start time
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 600
+          mode: box
+    description:
+      name: Description
+      description: Optional workout notes
+      required: false
+      selector:
+        text:
+    is_private:
+      name: Private
+      description: Hide the workout from your Hevy followers
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -22,7 +22,7 @@ get_workout_history:
 
 log_workout:
   name: Log workout
-  description: Posts a completed workout to Hevy with full exercise and set detail. Hevy has no delete, so logged workouts are permanent.
+  description: Posts a completed workout to Hevy with full exercise and set detail. Mistaken logs can only be deleted in the Hevy mobile app.
   fields:
     config_entry_id:
       name: Config entry ID

--- a/info.md
+++ b/info.md
@@ -6,14 +6,15 @@ Track your [Hevy](https://www.hevyapp.com/) workouts in Home Assistant with rich
 
 ## Features
 
-- **Summary sensors** — workout count, streaks, weekly activity, and worked out today/this week
-- **Per-exercise sensors** — automatically created for each exercise, with personal records and full set history
-- **Muscle group tracking** — which muscles were hit, days since last trained, and which are due
-- **Weekly volume analysis** — volume per muscle group with exercise breakdown
-- **Routine rotation** — detects the next workout in your A/B/C rotation
-- **30-day history** — service call returning enriched workout data for use in automations
-- **Unit support** — imperial (lbs) or metric (kg)
-- **Configurable polling** — 5 to 120 minute intervals
+- **Summary sensors**: workout count, streaks, weekly activity, and worked out today/this week
+- **Per-exercise sensors**: automatically created for each exercise, with personal records and full set history
+- **Muscle group tracking**: which muscles were hit, days since last trained, and which are due
+- **Weekly volume analysis**: volume per muscle group with exercise breakdown
+- **Routine rotation**: detects the next workout in your A/B/C rotation
+- **30-day history**: service call returning enriched workout data for use in automations
+- **Workout logging**: service call that posts a completed workout back to Hevy
+- **Unit support**: imperial (lbs) or metric (kg)
+- **Configurable polling**: 5 to 120 minute intervals
 
 ## Setup
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -325,6 +325,15 @@ class TestResponseAndErrors:
         response = await _log(hass)
         assert response == {"workout_id": "w-9", "title": "Leg Day"}
 
+    async def test_handles_list_workout_response(
+        self, hass, imperial_setup
+    ) -> None:
+        imperial_setup.client.create_workout = AsyncMock(
+            return_value={"workout": [{"id": "w-7", "title": "Pull Day"}]}
+        )
+        response = await _log(hass)
+        assert response == {"workout_id": "w-7", "title": "Pull Day"}
+
     async def test_refresh_requested_after_success(
         self, hass, imperial_setup
     ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+import voluptuous as vol
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.hevy.api import HevyApiClient, HevyApiError, HevyAuthError
+from custom_components.hevy.const import DOMAIN
+from custom_components.hevy.services import (
+    SERVICE_LOG_WORKOUT,
+    async_register_services,
+)
+
+ENTRY_ID = "entry_1"
+
+TEMPLATES = {
+    "t1": {"title": "Bench Press", "muscle_group": "chest"},
+    "t2": {"title": "Incline Bench Press", "muscle_group": "chest"},
+    "t3": {"title": "Running", "muscle_group": "cardio"},
+    "t4": {"title": "Close Grip Bench Press", "muscle_group": "triceps"},
+}
+
+
+def _register(hass, coordinator):
+    coordinator._exercise_templates = dict(TEMPLATES)
+    coordinator.client.create_workout = AsyncMock(
+        return_value={"id": "w-123", "title": "Push Day"}
+    )
+    coordinator.async_request_refresh = AsyncMock()
+    hass.data.setdefault(DOMAIN, {})[ENTRY_ID] = coordinator
+    async_register_services(hass)
+    return coordinator
+
+
+@pytest.fixture
+async def imperial_setup(hass, imperial_coordinator):
+    return _register(hass, imperial_coordinator)
+
+
+@pytest.fixture
+async def metric_setup(hass, metric_coordinator):
+    return _register(hass, metric_coordinator)
+
+
+def _call_data(**overrides):
+    data = {
+        "config_entry_id": ENTRY_ID,
+        "title": "Push Day",
+        "exercises": [
+            {
+                "name": "Bench Press",
+                "sets": [{"type": "normal", "weight": 225, "reps": 5}],
+            }
+        ],
+        "start_time": "2026-08-20T17:00:00+00:00",
+        "end_time": "2026-08-20T18:00:00+00:00",
+    }
+    data.update(overrides)
+    return data
+
+
+async def _log(hass, **overrides):
+    return await hass.services.async_call(
+        DOMAIN,
+        SERVICE_LOG_WORKOUT,
+        _call_data(**overrides),
+        blocking=True,
+        return_response=True,
+    )
+
+
+class TestSchema:
+    async def test_service_is_registered(self, hass, imperial_setup) -> None:
+        assert hass.services.has_service(DOMAIN, SERVICE_LOG_WORKOUT)
+
+    async def test_missing_title(self, hass, imperial_setup) -> None:
+        data = _call_data()
+        del data["title"]
+        with pytest.raises(vol.Invalid):
+            await hass.services.async_call(
+                DOMAIN, SERVICE_LOG_WORKOUT, data, blocking=True
+            )
+
+    async def test_empty_exercises(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(hass, exercises=[])
+
+    async def test_empty_sets(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(hass, exercises=[{"name": "Bench Press", "sets": []}])
+
+    async def test_set_without_measurement(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[{"name": "Bench Press", "sets": [{"type": "normal"}]}],
+            )
+
+    async def test_bad_set_type(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[
+                    {"name": "Bench Press", "sets": [{"type": "cooldown", "reps": 5}]}
+                ],
+            )
+
+    async def test_bad_rpe(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[
+                    {"name": "Bench Press", "sets": [{"reps": 5, "rpe": 8.2}]}
+                ],
+            )
+
+    async def test_valid_rpe_accepted(self, hass, imperial_setup) -> None:
+        await _log(
+            hass,
+            exercises=[{"name": "Bench Press", "sets": [{"reps": 5, "rpe": 8.5}]}],
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["rpe"] == 8.5
+
+
+class TestNameResolution:
+    async def test_exact_match(self, hass, imperial_setup) -> None:
+        await _log(hass)
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["exercise_template_id"] == "t1"
+
+    async def test_case_insensitive_match(self, hass, imperial_setup) -> None:
+        await _log(
+            hass,
+            exercises=[{"name": "bench PRESS", "sets": [{"reps": 5}]}],
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["exercise_template_id"] == "t1"
+
+    async def test_unknown_exercise_lists_suggestions(
+        self, hass, imperial_setup
+    ) -> None:
+        with pytest.raises(HomeAssistantError) as err:
+            await _log(
+                hass,
+                exercises=[{"name": "bench press machine", "sets": [{"reps": 5}]}],
+            )
+        message = str(err.value)
+        assert "bench press machine" in message
+        with pytest.raises(HomeAssistantError) as err:
+            await _log(
+                hass,
+                exercises=[{"name": "Bench", "sets": [{"reps": 5}]}],
+            )
+        message = str(err.value)
+        assert "Bench Press" in message
+        assert message.count(",") <= 2
+
+    async def test_nothing_posted_on_miss(self, hass, imperial_setup) -> None:
+        with pytest.raises(HomeAssistantError):
+            await _log(
+                hass,
+                exercises=[
+                    {"name": "Bench Press", "sets": [{"reps": 5}]},
+                    {"name": "Nonexistent Lift", "sets": [{"reps": 5}]},
+                ],
+            )
+        imperial_setup.client.create_workout.assert_not_awaited()
+        imperial_setup.async_request_refresh.assert_not_awaited()
+
+
+class TestConversion:
+    async def test_imperial_weight_to_kg(self, hass, imperial_setup) -> None:
+        await _log(hass)
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["weight_kg"] == 102.06
+
+    async def test_metric_weight_passthrough(self, hass, metric_setup) -> None:
+        await _log(
+            hass,
+            exercises=[
+                {"name": "Bench Press", "sets": [{"weight": 102.5, "reps": 5}]}
+            ],
+        )
+        payload = metric_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["weight_kg"] == 102.5
+
+    async def test_imperial_distance_to_meters(self, hass, imperial_setup) -> None:
+        await _log(
+            hass,
+            exercises=[
+                {
+                    "name": "Running",
+                    "sets": [{"distance": 3.1, "duration_seconds": 1500}],
+                }
+            ],
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["distance_meters"] == 4989
+
+    async def test_metric_distance_to_meters(self, hass, metric_setup) -> None:
+        await _log(
+            hass,
+            exercises=[{"name": "Running", "sets": [{"distance": 5.0}]}],
+        )
+        payload = metric_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["distance_meters"] == 5000
+
+
+class TestPayload:
+    async def test_full_payload_shape(self, hass, imperial_setup) -> None:
+        await _log(
+            hass,
+            description="Felt strong",
+            is_private=True,
+            exercises=[
+                {
+                    "name": "Bench Press",
+                    "notes": "Paused reps",
+                    "sets": [
+                        {"type": "warmup", "weight": 135, "reps": 8},
+                        {"weight": 225, "reps": 5, "rpe": 9},
+                    ],
+                },
+                {
+                    "name": "Running",
+                    "sets": [{"distance": 3.1, "duration_seconds": 1500}],
+                },
+            ],
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload == {
+            "workout": {
+                "title": "Push Day",
+                "description": "Felt strong",
+                "is_private": True,
+                "start_time": "2026-08-20T17:00:00+00:00",
+                "end_time": "2026-08-20T18:00:00+00:00",
+                "exercises": [
+                    {
+                        "exercise_template_id": "t1",
+                        "notes": "Paused reps",
+                        "sets": [
+                            {
+                                "type": "warmup",
+                                "weight_kg": 61.24,
+                                "reps": 8,
+                                "distance_meters": None,
+                                "duration_seconds": None,
+                                "rpe": None,
+                            },
+                            {
+                                "type": "normal",
+                                "weight_kg": 102.06,
+                                "reps": 5,
+                                "distance_meters": None,
+                                "duration_seconds": None,
+                                "rpe": 9,
+                            },
+                        ],
+                    },
+                    {
+                        "exercise_template_id": "t3",
+                        "notes": None,
+                        "sets": [
+                            {
+                                "type": "normal",
+                                "weight_kg": None,
+                                "reps": None,
+                                "distance_meters": 4989,
+                                "duration_seconds": 1500,
+                                "rpe": None,
+                            }
+                        ],
+                    },
+                ],
+            }
+        }
+
+    async def test_description_omitted_when_absent(
+        self, hass, imperial_setup
+    ) -> None:
+        await _log(hass)
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert "description" not in payload["workout"]
+        assert payload["workout"]["is_private"] is False
+
+    async def test_duration_minutes_derives_start_time(
+        self, hass, imperial_setup
+    ) -> None:
+        data = _call_data(duration_minutes=45)
+        del data["start_time"]
+        await hass.services.async_call(
+            DOMAIN, SERVICE_LOG_WORKOUT, data, blocking=True, return_response=True
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["start_time"] == "2026-08-20T17:15:00+00:00"
+        assert payload["workout"]["end_time"] == "2026-08-20T18:00:00+00:00"
+
+    async def test_defaults_to_now(self, hass, imperial_setup) -> None:
+        data = _call_data()
+        del data["start_time"]
+        del data["end_time"]
+        await hass.services.async_call(
+            DOMAIN, SERVICE_LOG_WORKOUT, data, blocking=True, return_response=True
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["start_time"] == payload["workout"]["end_time"]
+        assert payload["workout"]["end_time"]
+
+
+class TestResponseAndErrors:
+    async def test_returns_workout_id_and_title(self, hass, imperial_setup) -> None:
+        response = await _log(hass)
+        assert response == {"workout_id": "w-123", "title": "Push Day"}
+
+    async def test_handles_nested_workout_response(
+        self, hass, imperial_setup
+    ) -> None:
+        imperial_setup.client.create_workout = AsyncMock(
+            return_value={"workout": {"id": "w-9", "title": "Leg Day"}}
+        )
+        response = await _log(hass)
+        assert response == {"workout_id": "w-9", "title": "Leg Day"}
+
+    async def test_refresh_requested_after_success(
+        self, hass, imperial_setup
+    ) -> None:
+        await _log(hass)
+        imperial_setup.async_request_refresh.assert_awaited_once()
+
+    async def test_api_error_wrapped(self, hass, imperial_setup) -> None:
+        imperial_setup.client.create_workout = AsyncMock(
+            side_effect=HevyApiError("boom")
+        )
+        with pytest.raises(HomeAssistantError) as err:
+            await _log(hass)
+        assert "boom" in str(err.value)
+        imperial_setup.async_request_refresh.assert_not_awaited()
+
+    async def test_auth_error_wrapped(self, hass, imperial_setup) -> None:
+        imperial_setup.client.create_workout = AsyncMock(
+            side_effect=HevyAuthError("Invalid API key")
+        )
+        with pytest.raises(HomeAssistantError) as err:
+            await _log(hass)
+        assert "Invalid API key" in str(err.value)
+
+    async def test_unknown_config_entry(self, hass, imperial_setup) -> None:
+        with pytest.raises(ValueError):
+            await _log(hass, config_entry_id="missing")
+
+
+class TestApiClient:
+    async def test_create_workout_posts_json(self) -> None:
+        client = HevyApiClient("key")
+        client._request = AsyncMock(return_value={"id": "w-1"})
+        workout = {"workout": {"title": "Push Day"}}
+
+        assert await client.create_workout(workout) == {"id": "w-1"}
+        assert client._request.await_args.args == ("POST", "/workouts")
+        assert client._request.await_args.kwargs == {"json": workout}


### PR DESCRIPTION
## Summary
- New `hevy.log_workout` service that posts a completed workout to Hevy
- Exercise names resolve against the cached exercise catalog, with near-miss suggestions when a name doesn't match
- Weights and distances are accepted in the configured unit system and converted for the API (kg, meters)
- Sensors, streak, and calendar refresh immediately after a successful log
- Optional service response returns the new workout's ID and title
- Docs for the new service in README and info.md, changelog entry, version bumped to 1.3.0

Closes #23

## Test plan
- [x] `ruff check custom_components/hevy tests` clean
- [x] `pytest -q` green, 86 passed (24 new tests covering schema validation, name resolution, unit conversion, payload shape, refresh behavior, and error wrapping)
- [x] Live smoke test against a real Hevy account: workout created with correct weight, reps, and timestamps, response ID returned