### PR TITLE
Tighten service validation and template cache access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `hevy.log_workout` now rejects negative weight, reps, duration, and distance values, and accepts RPE as a string or a number
+- `hevy.get_workout_history` and `hevy.log_workout` now raise a proper validation error (instead of a generic one) when the config entry ID does not match a configured Hevy integration
+
 ## [1.3.0] - 2026-08-20
 
 ### Added

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -57,6 +57,10 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._exercise_templates: dict[str, dict] = {}  # Cache templates by ID
         self._routines: list[dict[str, Any]] = []
 
+    @property
+    def exercise_templates(self) -> dict[str, dict]:
+        return self._exercise_templates
+
     async def fetch_exercise_templates(self) -> None:
         """Fetch and cache exercise template catalog from all pages."""
         try:

--- a/custom_components/hevy/sensor.py
+++ b/custom_components/hevy/sensor.py
@@ -431,8 +431,8 @@ class HevyExerciseSensor(CoordinatorEntity[HevyDataUpdateCoordinator], SensorEnt
 
         # Enrich with template data if available
         template_id = exercise_data.get("exercise_template_id")
-        if template_id and template_id in self.coordinator._exercise_templates:
-            template = self.coordinator._exercise_templates[template_id]
+        if template_id and template_id in self.coordinator.exercise_templates:
+            template = self.coordinator.exercise_templates[template_id]
             attrs.update(
                 {
                     "muscle_group": template.get("muscle_group"),

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -12,7 +12,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
@@ -32,7 +32,7 @@ SERVICE_GET_WORKOUT_HISTORY = "get_workout_history"
 SERVICE_LOG_WORKOUT = "log_workout"
 
 SET_TYPES = ["warmup", "normal", "failure", "dropset"]
-RPE_VALUES = [6, 7, 7.5, 8, 8.5, 9, 9.5, 10]
+RPE_VALUES = [6.0, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0]
 MEASUREMENT_FIELDS = ("weight", "reps", "duration_seconds", "distance")
 MAX_NAME_SUGGESTIONS = 3
 
@@ -59,11 +59,13 @@ SET_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Optional("type", default="normal"): vol.In(SET_TYPES),
-            vol.Optional("weight"): vol.Coerce(float),
-            vol.Optional("reps"): vol.Coerce(int),
-            vol.Optional("duration_seconds"): vol.Coerce(int),
-            vol.Optional("distance"): vol.Coerce(float),
-            vol.Optional("rpe"): vol.In(RPE_VALUES),
+            vol.Optional("weight"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+            vol.Optional("reps"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Optional("duration_seconds"): vol.All(
+                vol.Coerce(int), vol.Range(min=0)
+            ),
+            vol.Optional("distance"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+            vol.Optional("rpe"): vol.All(vol.Coerce(float), vol.In(RPE_VALUES)),
         }
     ),
     _set_has_measurement,
@@ -120,7 +122,7 @@ def _to_meters(
 def _resolve_template_id(
     coordinator: HevyDataUpdateCoordinator, name: str
 ) -> str:
-    templates = coordinator._exercise_templates
+    templates = coordinator.exercise_templates
 
     for template_id, template in templates.items():
         if template.get("title") == name:
@@ -155,7 +157,7 @@ def async_register_services(hass: HomeAssistant) -> None:
         config_entry_id = call.data["config_entry_id"]
 
         if config_entry_id not in hass.data.get(DOMAIN, {}):
-            raise ValueError(f"Config entry {config_entry_id} not found")
+            raise ServiceValidationError(f"Config entry {config_entry_id} not found")
 
         coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][config_entry_id]
         cutoff = dt_util.now() - timedelta(days=days)
@@ -224,8 +226,8 @@ def async_register_services(hass: HomeAssistant) -> None:
             for exercise in workout.get("exercises", []):
                 template_id = exercise.get("exercise_template_id")
                 muscle_group = None
-                if template_id and template_id in coordinator._exercise_templates:
-                    template = coordinator._exercise_templates[template_id]
+                if template_id and template_id in coordinator.exercise_templates:
+                    template = coordinator.exercise_templates[template_id]
                     muscle_group = template.get("muscle_group")
                     if muscle_group and muscle_group not in seen_groups:
                         muscle_groups.append(muscle_group)
@@ -293,7 +295,7 @@ def async_register_services(hass: HomeAssistant) -> None:
         config_entry_id = call.data["config_entry_id"]
 
         if config_entry_id not in hass.data.get(DOMAIN, {}):
-            raise ValueError(f"Config entry {config_entry_id} not found")
+            raise ServiceValidationError(f"Config entry {config_entry_id} not found")
 
         coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][config_entry_id]
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,11 +4,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 import voluptuous as vol
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.hevy.api import HevyApiClient, HevyApiError, HevyAuthError
 from custom_components.hevy.const import DOMAIN
 from custom_components.hevy.services import (
+    SERVICE_GET_WORKOUT_HISTORY,
     SERVICE_LOG_WORKOUT,
     async_register_services,
 )
@@ -123,6 +124,52 @@ class TestSchema:
         )
         payload = imperial_setup.client.create_workout.await_args.args[0]
         assert payload["workout"]["exercises"][0]["sets"][0]["rpe"] == 8.5
+
+    async def test_rpe_as_string_accepted(self, hass, imperial_setup) -> None:
+        await _log(
+            hass,
+            exercises=[{"name": "Bench Press", "sets": [{"reps": 5, "rpe": "8.5"}]}],
+        )
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        assert payload["workout"]["exercises"][0]["sets"][0]["rpe"] == 8.5
+
+    async def test_negative_weight_rejected(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[
+                    {"name": "Bench Press", "sets": [{"weight": -5, "reps": 5}]}
+                ],
+            )
+        imperial_setup.client.create_workout.assert_not_awaited()
+
+    async def test_negative_reps_rejected(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[{"name": "Bench Press", "sets": [{"reps": -5}]}],
+            )
+        imperial_setup.client.create_workout.assert_not_awaited()
+
+    async def test_negative_duration_seconds_rejected(
+        self, hass, imperial_setup
+    ) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[
+                    {"name": "Running", "sets": [{"duration_seconds": -5}]}
+                ],
+            )
+        imperial_setup.client.create_workout.assert_not_awaited()
+
+    async def test_negative_distance_rejected(self, hass, imperial_setup) -> None:
+        with pytest.raises(vol.Invalid):
+            await _log(
+                hass,
+                exercises=[{"name": "Running", "sets": [{"distance": -5}]}],
+            )
+        imperial_setup.client.create_workout.assert_not_awaited()
 
 
 class TestNameResolution:
@@ -358,8 +405,18 @@ class TestResponseAndErrors:
         assert "Invalid API key" in str(err.value)
 
     async def test_unknown_config_entry(self, hass, imperial_setup) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ServiceValidationError):
             await _log(hass, config_entry_id="missing")
+
+    async def test_unknown_config_entry_history(self, hass, imperial_setup) -> None:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_WORKOUT_HISTORY,
+                {"config_entry_id": "missing"},
+                blocking=True,
+                return_response=True,
+            )
 
 
 class TestApiClient:


### PR DESCRIPTION
## Summary
- Reject negative weight, reps, duration_seconds, and distance in hevy.log_workout sets instead of posting them to Hevy
- Accept RPE passed as a string from raw YAML scripts (coerced to float before validation)
- Raise ServiceValidationError instead of bare ValueError for an unknown config_entry_id in both service handlers
- Add a public exercise_templates accessor on the coordinator and use it from services and sensors instead of the private attribute

## Test plan
- [x] ruff check custom_components/hevy tests
- [x] pytest: 92 passed, including new tests for string RPE, each negative field, and the validation error type for both services