### PR TITLE
Add read services for the exercise catalog and routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `hevy.get_exercise_catalog` service that returns the cached Hevy exercise catalog sorted by title, so you can look up the exact names `hevy.log_workout` accepts
+- `hevy.get_routines` service that returns your saved routines with full exercise and set detail in your configured unit system. The sets it returns can be passed straight to `hevy.log_workout`
+
 ### Changed
 - `hevy.log_workout` now rejects negative weight, reps, duration, and distance values, and accepts RPE as a string or a number
 - `hevy.get_workout_history` and `hevy.log_workout` now raise a proper validation error (instead of a generic one) when the config entry ID does not match a configured Hevy integration

--- a/README.md
+++ b/README.md
@@ -733,6 +733,90 @@ action:
 
 </details>
 
+### `hevy.get_exercise_catalog`
+
+Returns the cached Hevy exercise catalog, sorted by title. Use it to find the exact names `hevy.log_workout` expects.
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `config_entry_id` | Yes | none | The Hevy integration config entry ID |
+
+**Response includes:**
+- `count`: Number of exercises in the catalog
+- `exercises`: Array of `{ id, title, muscle_group }`
+
+<details>
+<summary><b>Example call and response</b></summary>
+
+```yaml
+action:
+  - service: hevy.get_exercise_catalog
+    data:
+      config_entry_id: YOUR_CONFIG_ENTRY_ID
+    response_variable: catalog
+```
+
+```yaml
+count: 412
+exercises:
+  - id: 79D0BB3A
+    title: Bench Press (Barbell)
+    muscle_group: chest
+  - id: 0393F233
+    title: Bicep Curl (Dumbbell)
+    muscle_group: biceps
+```
+
+</details>
+
+### `hevy.get_routines`
+
+Returns your saved Hevy routines with every exercise and set. Weights and distances come back in the unit system configured for the integration, so a routine's sets can be handed straight to `hevy.log_workout`.
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `config_entry_id` | Yes | none | The Hevy integration config entry ID |
+
+**Response includes:**
+- `count`: Number of routines
+- `routines`: Array of `{ id, title, exercises }`, where each exercise has a `name`, an `exercise_template_id`, and a list of sets. A set always has a `type`, plus whichever of `weight`, `reps`, `duration_seconds`, and `distance` the routine defines.
+
+<details>
+<summary><b>Example call and response</b></summary>
+
+```yaml
+action:
+  - service: hevy.get_routines
+    data:
+      config_entry_id: YOUR_CONFIG_ENTRY_ID
+    response_variable: routines
+```
+
+```yaml
+count: 2
+routines:
+  - id: r-8f21
+    title: Push Day
+    exercises:
+      - name: Bench Press
+        exercise_template_id: 79D0BB3A
+        sets:
+          - type: warmup
+            weight: 135
+            reps: 8
+          - type: normal
+            weight: 225
+            reps: 5
+      - name: Running
+        exercise_template_id: AC1BB830
+        sets:
+          - type: normal
+            duration_seconds: 1500
+            distance: 3.1
+```
+
+</details>
+
 ### `hevy.log_workout`
 
 Posts a completed workout to Hevy. Exercise names are matched against your Hevy exercise catalog (exact first, then case-insensitive), and weights and distances are sent in the unit system configured for the integration. If any exercise name cannot be matched, nothing is posted and the error lists the closest names.

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -61,6 +61,10 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def exercise_templates(self) -> dict[str, dict]:
         return self._exercise_templates
 
+    @property
+    def routines(self) -> list[dict[str, Any]]:
+        return self._routines
+
     async def fetch_exercise_templates(self) -> None:
         """Fetch and cache exercise template catalog from all pages."""
         try:
@@ -111,10 +115,29 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 routine_id = routine.get("id")
                 if routine_id:
                     exercises = []
-                    for exercise in routine.get("exercises", []):
+                    for exercise in routine.get("exercises") or []:
                         title = exercise.get("title")
                         if title:
-                            exercises.append(title)
+                            exercises.append({
+                                "name": title,
+                                "exercise_template_id": exercise.get(
+                                    "exercise_template_id"
+                                ),
+                                "sets": [
+                                    {
+                                        "type": set_data.get("type", "normal"),
+                                        "weight_kg": set_data.get("weight_kg"),
+                                        "reps": set_data.get("reps"),
+                                        "duration_seconds": set_data.get(
+                                            "duration_seconds"
+                                        ),
+                                        "distance_meters": set_data.get(
+                                            "distance_meters"
+                                        ),
+                                    }
+                                    for set_data in exercise.get("sets") or []
+                                ],
+                            })
                     self._routines.append({
                         "id": routine_id,
                         "title": routine.get("title", "Untitled"),
@@ -165,6 +188,14 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return all_workouts
 
+    @staticmethod
+    def _routine_exercise_titles(routine: dict[str, Any]) -> list[str]:
+        return [
+            exercise["name"]
+            for exercise in routine.get("exercises", [])
+            if exercise.get("name")
+        ]
+
     def _detect_next_workout(self) -> dict[str, Any]:
         """Detect the next workout in the routine rotation.
 
@@ -195,7 +226,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "last_workout_routine_id": None,
                 "rotation_position": 1,
                 "rotation_total": len(self._routines),
-                "exercises_preview": first["exercises"],
+                "exercises_preview": self._routine_exercise_titles(first),
             }
 
         last_routine_id = last_workout.get("routine_id")
@@ -232,7 +263,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "last_workout_routine_id": last_routine_id,
             "rotation_position": next_index + 1,
             "rotation_total": len(self._routines),
-            "exercises_preview": next_routine["exercises"],
+            "exercises_preview": self._routine_exercise_titles(next_routine),
         }
 
     def _aggregate_muscle_groups(self) -> dict[str, Any]:

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -30,6 +30,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_GET_WORKOUT_HISTORY = "get_workout_history"
 SERVICE_LOG_WORKOUT = "log_workout"
+SERVICE_GET_EXERCISE_CATALOG = "get_exercise_catalog"
+SERVICE_GET_ROUTINES = "get_routines"
 
 SET_TYPES = ["warmup", "normal", "failure", "dropset"]
 RPE_VALUES = [6.0, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0]
@@ -42,6 +44,13 @@ WORKOUT_HISTORY_SCHEMA = vol.Schema(
         vol.Optional("days", default=30): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=90)
         ),
+    }
+)
+
+
+CONFIG_ENTRY_ONLY_SCHEMA = vol.Schema(
+    {
+        vol.Required("config_entry_id"): cv.string,
     }
 )
 
@@ -358,6 +367,77 @@ def async_register_services(hass: HomeAssistant) -> None:
             "title": result.get("title"),
         }
 
+    async def handle_get_exercise_catalog(call: ServiceCall) -> ServiceResponse:
+        config_entry_id = call.data["config_entry_id"]
+
+        if config_entry_id not in hass.data.get(DOMAIN, {}):
+            raise ServiceValidationError(f"Config entry {config_entry_id} not found")
+
+        coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][config_entry_id]
+
+        exercises = [
+            {
+                "id": template_id,
+                "title": template.get("title"),
+                "muscle_group": template.get("muscle_group"),
+            }
+            for template_id, template in coordinator.exercise_templates.items()
+        ]
+        exercises.sort(key=lambda exercise: exercise["title"] or "")
+
+        return {
+            "count": len(exercises),
+            "exercises": exercises,
+        }
+
+    async def handle_get_routines(call: ServiceCall) -> ServiceResponse:
+        config_entry_id = call.data["config_entry_id"]
+
+        if config_entry_id not in hass.data.get(DOMAIN, {}):
+            raise ServiceValidationError(f"Config entry {config_entry_id} not found")
+
+        coordinator: HevyDataUpdateCoordinator = hass.data[DOMAIN][config_entry_id]
+
+        routines_response: list[dict[str, Any]] = []
+        for routine in coordinator.routines:
+            exercises_response: list[dict[str, Any]] = []
+            for exercise in routine.get("exercises", []):
+                sets_response: list[dict[str, Any]] = []
+                for set_data in exercise.get("sets", []):
+                    set_response: dict[str, Any] = {
+                        "type": set_data.get("type", "normal")
+                    }
+                    weight = coordinator._convert_weight(set_data.get("weight_kg"))
+                    if weight is not None:
+                        set_response["weight"] = weight
+                    if set_data.get("reps") is not None:
+                        set_response["reps"] = set_data["reps"]
+                    if set_data.get("duration_seconds") is not None:
+                        set_response["duration_seconds"] = set_data["duration_seconds"]
+                    distance = coordinator._convert_distance(
+                        set_data.get("distance_meters")
+                    )
+                    if distance is not None:
+                        set_response["distance"] = distance
+                    sets_response.append(set_response)
+
+                exercises_response.append({
+                    "name": exercise.get("name"),
+                    "exercise_template_id": exercise.get("exercise_template_id"),
+                    "sets": sets_response,
+                })
+
+            routines_response.append({
+                "id": routine.get("id"),
+                "title": routine.get("title"),
+                "exercises": exercises_response,
+            })
+
+        return {
+            "count": len(routines_response),
+            "routines": routines_response,
+        }
+
     if not hass.services.has_service(DOMAIN, SERVICE_GET_WORKOUT_HISTORY):
         hass.services.async_register(
             DOMAIN,
@@ -376,9 +456,29 @@ def async_register_services(hass: HomeAssistant) -> None:
             supports_response=SupportsResponse.OPTIONAL,
         )
 
+    if not hass.services.has_service(DOMAIN, SERVICE_GET_EXERCISE_CATALOG):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_GET_EXERCISE_CATALOG,
+            handle_get_exercise_catalog,
+            schema=CONFIG_ENTRY_ONLY_SCHEMA,
+            supports_response=SupportsResponse.ONLY,
+        )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_GET_ROUTINES):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_GET_ROUTINES,
+            handle_get_routines,
+            schema=CONFIG_ENTRY_ONLY_SCHEMA,
+            supports_response=SupportsResponse.ONLY,
+        )
+
 
 def async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister Hevy services if no more config entries."""
     if not hass.data.get(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_GET_WORKOUT_HISTORY)
         hass.services.async_remove(DOMAIN, SERVICE_LOG_WORKOUT)
+        hass.services.async_remove(DOMAIN, SERVICE_GET_EXERCISE_CATALOG)
+        hass.services.async_remove(DOMAIN, SERVICE_GET_ROUTINES)

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -20,6 +20,30 @@ get_workout_history:
         config_entry:
           integration: hevy
 
+get_exercise_catalog:
+  name: Get exercise catalog
+  description: Returns the cached Hevy exercise catalog so you can look up the exact names log_workout accepts.
+  fields:
+    config_entry_id:
+      name: Config entry ID
+      description: The Hevy integration config entry ID
+      required: true
+      selector:
+        config_entry:
+          integration: hevy
+
+get_routines:
+  name: Get routines
+  description: Returns your saved Hevy routines with full set detail, in the unit system configured for the integration. The sets can be passed straight to log_workout.
+  fields:
+    config_entry_id:
+      name: Config entry ID
+      description: The Hevy integration config entry ID
+      required: true
+      selector:
+        config_entry:
+          integration: hevy
+
 log_workout:
   name: Log workout
   description: Posts a completed workout to Hevy with full exercise and set detail. Mistaken logs can only be deleted in the Hevy mobile app.

--- a/info.md
+++ b/info.md
@@ -13,6 +13,7 @@ Track your [Hevy](https://www.hevyapp.com/) workouts in Home Assistant with rich
 - **Routine rotation**: detects the next workout in your A/B/C rotation
 - **30-day history**: service call returning enriched workout data for use in automations
 - **Workout logging**: service call that posts a completed workout back to Hevy
+- **Catalog and routine lookups**: service calls returning your exercise catalog and your saved routines, ready to feed back into workout logging
 - **Unit support**: imperial (lbs) or metric (kg)
 - **Configurable polling**: 5 to 120 minute intervals
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,61 @@ import pytest
 from custom_components.hevy.const import UNIT_SYSTEM_IMPERIAL, UNIT_SYSTEM_METRIC
 from custom_components.hevy.coordinator import HevyDataUpdateCoordinator
 
+ROUTINES_RESPONSE = {
+    "routines": [
+        {
+            "id": "r1",
+            "title": "Push Day",
+            "exercises": [
+                {
+                    "title": "Bench Press",
+                    "exercise_template_id": "t1",
+                    "sets": [
+                        {
+                            "type": "warmup",
+                            "weight_kg": 61.24,
+                            "reps": 8,
+                            "duration_seconds": None,
+                            "distance_meters": None,
+                        },
+                        {
+                            "type": "normal",
+                            "weight_kg": 102.06,
+                            "reps": 5,
+                            "duration_seconds": None,
+                            "distance_meters": None,
+                        },
+                    ],
+                },
+                {
+                    "title": "Running",
+                    "exercise_template_id": "t3",
+                    "sets": [
+                        {
+                            "type": "normal",
+                            "weight_kg": None,
+                            "reps": None,
+                            "duration_seconds": 1500,
+                            "distance_meters": 4989,
+                        }
+                    ],
+                },
+            ],
+        },
+        {
+            "id": "r2",
+            "title": "Mobility",
+            "exercises": [
+                {
+                    "title": "Hip Openers",
+                    "exercise_template_id": "t5",
+                    "sets": None,
+                }
+            ],
+        },
+    ]
+}
+
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
@@ -23,7 +78,7 @@ def mock_client() -> MagicMock:
     client.get_exercise_templates = AsyncMock(
         return_value={"exercise_templates": [], "page_count": 1}
     )
-    client.get_routines = AsyncMock(return_value={"routines": []})
+    client.get_routines = AsyncMock(return_value=ROUTINES_RESPONSE)
     return client
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -272,3 +272,76 @@ class TestFetch30DayWorkouts:
         result = await imperial_coordinator._fetch_30_day_workouts()
         assert result == []
         assert mock_client.get_workouts.call_count == 1
+
+
+class TestFetchRoutines:
+    async def test_caches_full_set_detail(self, imperial_coordinator) -> None:
+        await imperial_coordinator.fetch_routines()
+        push_day = imperial_coordinator.routines[0]
+        assert push_day["id"] == "r1"
+        assert push_day["title"] == "Push Day"
+        assert push_day["exercises"][0] == {
+            "name": "Bench Press",
+            "exercise_template_id": "t1",
+            "sets": [
+                {
+                    "type": "warmup",
+                    "weight_kg": 61.24,
+                    "reps": 8,
+                    "duration_seconds": None,
+                    "distance_meters": None,
+                },
+                {
+                    "type": "normal",
+                    "weight_kg": 102.06,
+                    "reps": 5,
+                    "duration_seconds": None,
+                    "distance_meters": None,
+                },
+            ],
+        }
+        assert push_day["exercises"][1]["sets"][0]["distance_meters"] == 4989
+
+    async def test_exercise_without_sets(self, imperial_coordinator) -> None:
+        await imperial_coordinator.fetch_routines()
+        mobility = imperial_coordinator.routines[1]
+        assert mobility["exercises"] == [
+            {
+                "name": "Hip Openers",
+                "exercise_template_id": "t5",
+                "sets": [],
+            }
+        ]
+
+    async def test_routine_without_exercises(
+        self, imperial_coordinator, mock_client
+    ) -> None:
+        mock_client.get_routines.return_value = {
+            "routines": [{"id": "r9", "title": "Empty", "exercises": None}]
+        }
+        await imperial_coordinator.fetch_routines()
+        assert imperial_coordinator.routines == [
+            {"id": "r9", "title": "Empty", "exercises": []}
+        ]
+
+
+class TestDetectNextWorkout:
+    async def test_no_routines(self, imperial_coordinator) -> None:
+        result = imperial_coordinator._detect_next_workout()
+        assert result["exercises_preview"] == []
+        assert result["rotation_total"] == 0
+
+    async def test_preview_is_exercise_titles(self, imperial_coordinator) -> None:
+        await imperial_coordinator.fetch_routines()
+        result = imperial_coordinator._detect_next_workout()
+        assert result["next_routine"] == "Push Day"
+        assert result["exercises_preview"] == ["Bench Press", "Running"]
+
+    async def test_preview_after_last_workout(self, imperial_coordinator) -> None:
+        await imperial_coordinator.fetch_routines()
+        imperial_coordinator._workout_history = [
+            {"routine_id": "r1", "title": "Push Day"}
+        ]
+        result = imperial_coordinator._detect_next_workout()
+        assert result["routine_id"] == "r2"
+        assert result["exercises_preview"] == ["Hip Openers"]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,6 +9,8 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from custom_components.hevy.api import HevyApiClient, HevyApiError, HevyAuthError
 from custom_components.hevy.const import DOMAIN
 from custom_components.hevy.services import (
+    SERVICE_GET_EXERCISE_CATALOG,
+    SERVICE_GET_ROUTINES,
     SERVICE_GET_WORKOUT_HISTORY,
     SERVICE_LOG_WORKOUT,
     async_register_services,
@@ -428,3 +430,150 @@ class TestApiClient:
         assert await client.create_workout(workout) == {"id": "w-1"}
         assert client._request.await_args.args == ("POST", "/workouts")
         assert client._request.await_args.kwargs == {"json": workout}
+
+
+async def _catalog(hass, config_entry_id=ENTRY_ID):
+    return await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_EXERCISE_CATALOG,
+        {"config_entry_id": config_entry_id},
+        blocking=True,
+        return_response=True,
+    )
+
+
+async def _routines(hass, config_entry_id=ENTRY_ID):
+    return await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_ROUTINES,
+        {"config_entry_id": config_entry_id},
+        blocking=True,
+        return_response=True,
+    )
+
+
+class TestExerciseCatalog:
+    async def test_service_is_registered(self, hass, imperial_setup) -> None:
+        assert hass.services.has_service(DOMAIN, SERVICE_GET_EXERCISE_CATALOG)
+
+    async def test_returns_sorted_catalog(self, hass, imperial_setup) -> None:
+        response = await _catalog(hass)
+        assert response == {
+            "count": 4,
+            "exercises": [
+                {"id": "t1", "title": "Bench Press", "muscle_group": "chest"},
+                {
+                    "id": "t4",
+                    "title": "Close Grip Bench Press",
+                    "muscle_group": "triceps",
+                },
+                {
+                    "id": "t2",
+                    "title": "Incline Bench Press",
+                    "muscle_group": "chest",
+                },
+                {"id": "t3", "title": "Running", "muscle_group": "cardio"},
+            ],
+        }
+
+    async def test_empty_catalog(self, hass, imperial_setup) -> None:
+        imperial_setup._exercise_templates = {}
+        response = await _catalog(hass)
+        assert response == {"count": 0, "exercises": []}
+
+    async def test_unknown_config_entry(self, hass, imperial_setup) -> None:
+        with pytest.raises(ServiceValidationError):
+            await _catalog(hass, config_entry_id="missing")
+
+
+class TestGetRoutines:
+    async def test_service_is_registered(self, hass, imperial_setup) -> None:
+        assert hass.services.has_service(DOMAIN, SERVICE_GET_ROUTINES)
+
+    async def test_imperial_response_shape(self, hass, imperial_setup) -> None:
+        await imperial_setup.fetch_routines()
+        response = await _routines(hass)
+        assert response == {
+            "count": 2,
+            "routines": [
+                {
+                    "id": "r1",
+                    "title": "Push Day",
+                    "exercises": [
+                        {
+                            "name": "Bench Press",
+                            "exercise_template_id": "t1",
+                            "sets": [
+                                {"type": "warmup", "weight": 135.0, "reps": 8},
+                                {"type": "normal", "weight": 225.0, "reps": 5},
+                            ],
+                        },
+                        {
+                            "name": "Running",
+                            "exercise_template_id": "t3",
+                            "sets": [
+                                {
+                                    "type": "normal",
+                                    "duration_seconds": 1500,
+                                    "distance": 3.1,
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "id": "r2",
+                    "title": "Mobility",
+                    "exercises": [
+                        {
+                            "name": "Hip Openers",
+                            "exercise_template_id": "t5",
+                            "sets": [],
+                        }
+                    ],
+                },
+            ],
+        }
+
+    async def test_metric_converts_sets(self, hass, metric_setup) -> None:
+        await metric_setup.fetch_routines()
+        response = await _routines(hass)
+        push_day = response["routines"][0]
+        assert push_day["exercises"][0]["sets"] == [
+            {"type": "warmup", "weight": 61.0, "reps": 8},
+            {"type": "normal", "weight": 102.0, "reps": 5},
+        ]
+        assert push_day["exercises"][1]["sets"][0]["distance"] == 4.99
+
+    async def test_sets_round_trip_into_log_workout(
+        self, hass, imperial_setup
+    ) -> None:
+        await imperial_setup.fetch_routines()
+        response = await _routines(hass)
+        push_day = response["routines"][0]
+
+        await _log(
+            hass,
+            title=push_day["title"],
+            exercises=[
+                {"name": exercise["name"], "sets": exercise["sets"]}
+                for exercise in push_day["exercises"]
+                if exercise["sets"]
+            ],
+        )
+
+        payload = imperial_setup.client.create_workout.await_args.args[0]
+        bench, running = payload["workout"]["exercises"]
+        assert bench["exercise_template_id"] == "t1"
+        assert [s["weight_kg"] for s in bench["sets"]] == [61.24, 102.06]
+        assert [s["reps"] for s in bench["sets"]] == [8, 5]
+        assert running["sets"][0]["distance_meters"] == 4989
+        assert running["sets"][0]["duration_seconds"] == 1500
+
+    async def test_empty_routines(self, hass, imperial_setup) -> None:
+        response = await _routines(hass)
+        assert response == {"count": 0, "routines": []}
+
+    async def test_unknown_config_entry(self, hass, imperial_setup) -> None:
+        with pytest.raises(ServiceValidationError):
+            await _routines(hass, config_entry_id="missing")


### PR DESCRIPTION
## Summary
- New hevy.get_exercise_catalog service: cached exercise catalog as { count, exercises: [{ id, title, muscle_group }] }, sorted by title
- New hevy.get_routines service: saved routines with full exercise and set detail, weights and distances converted to the configured unit system so sets can be passed straight to hevy.log_workout
- Routine cache extended to keep full set detail; the next workout sensor's exercises_preview contract is unchanged
- README and services.yaml document both services with example calls and responses

## Test plan
- [x] ruff check custom_components/hevy tests
- [x] pytest: 108 passed, including response shapes, imperial and metric conversion, a round-trip from get_routines into log_workout, empty caches, and unknown config entry errors